### PR TITLE
ci: optimize to cancel preview pages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,12 +26,14 @@ jobs:
 
       - name: Cache
         uses: actions/cache@v4
+        if: github.event.action != 'closed'
         with:
           path: ~/.cache/vcpkg
           key: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
           restore-keys: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
 
       - uses: aminya/setup-cpp@v1
+        if: github.event.action != 'closed'
         with:
           compiler: gcc
           cmake: true
@@ -42,13 +44,16 @@ jobs:
           python: true
 
       - name: Install docs dependencies
+        if: github.event.action != 'closed'
         run: |
           pip install -r docs/requirements.txt
 
       - name: Configure
+        if: github.event.action != 'closed'
         run: cmake -S . --preset=x64-linux-gcc -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
 
       - name: Build Docs
+        if: github.event.action != 'closed'
         run: cmake --build out/build/x64-linux-gcc --target ss-cpp-docs
 
       - name: Deploy preview

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/preview.yml.jinja
@@ -26,12 +26,14 @@ jobs:
 
       - name: Cache
         uses: actions/cache@v4
+        if: github.event.action != 'closed'
         with:
           path: ~/.cache/vcpkg
           key: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
           restore-keys: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
 
       - uses: aminya/setup-cpp@v1
+        if: github.event.action != 'closed'
         with:
           compiler: gcc
           cmake: true
@@ -42,13 +44,16 @@ jobs:
           python: true
 
       - name: Install docs dependencies
+        if: github.event.action != 'closed'
         run: |
           pip install -r docs/requirements.txt
 
       - name: Configure
+        if: github.event.action != 'closed'
         run: cmake -S . --preset=x64-linux-gcc -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
 
       - name: Build Docs
+        if: github.event.action != 'closed'
         run: cmake --build out/build/x64-linux-gcc --target {{ repo_name }}-docs
 
       - name: Deploy preview


### PR DESCRIPTION
This prevents the preview pages job from disturbing the pages deploy job