### PR TITLE
ci: use ubuntu-latest but skip asan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         presets:
-          # use 20.04 and asan doesn't work on ubuntu-22.04 and the above versions, see https://github.com/google/googletest/issues/4491
-          - {os: {name: ubuntu-20.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
+          - {os: {name: ubuntu-latest, type: linux}, compiler: {name: gcc-11, type: gcc}}
           - {os: {name: ubuntu-latest, type: linux}, compiler: {name: llvm, type: llvm}}
           - {os: {name: ubuntu-latest, type: mingw-dynamic-linux}, compiler: {name: mingw, type: mingw}}
           - {os: {name: macos-latest, type: osx}, compiler: {name: applellvm, type: llvm}}
@@ -109,7 +108,7 @@ jobs:
             arch: {name: x64, type: x64}
             vcpkg: true
             export_mode: ON
-          - presets: {os: {name: ubuntu-20.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
+          - presets: {os: {name: ubuntu-latest, type: linux}, compiler: {name: gcc-11, type: gcc}}
             arch: {name: x64, type: x64}
             vcpkg: false
             export_mode: OFF
@@ -173,9 +172,10 @@ jobs:
           timeout 10s bash -c "while [ ! -f ~/.wine/system.reg ] ; do echo 'waiting for wine registry to be created' ; sleep 1 ; done" && echo "wine registry created"
           sed -i '/"PATH"/ s|"$|;Z:/usr/lib/gcc/x86_64-w64-mingw32/10-posix;Z:/usr/x86_64-w64-mingw32/lib"|g' ~/.wine/system.reg && echo "wine registry updated"
 
+      # skip asan on ubuntu-latest, see https://github.com/google/googletest/issues/4491
       - name: Configure CMake
         run: |
-          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
+          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.presets.os.type == 'linux' && '-DUSE_SANITIZER=OFF' || '' }} ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
 
       - name: Build
         run: |

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml
@@ -84,8 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         presets:
-          # use 20.04 and asan doesn't work on ubuntu-22.04 and the above versions, see https://github.com/google/googletest/issues/4491
-          - {os: {name: ubuntu-20.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
+          - {os: {name: ubuntu-latest, type: linux}, compiler: {name: gcc-11, type: gcc}}
           - {os: {name: ubuntu-latest, type: linux}, compiler: {name: llvm, type: llvm}}
           - {os: {name: ubuntu-latest, type: mingw-dynamic-linux}, compiler: {name: mingw, type: mingw}}
           - {os: {name: macos-latest, type: osx}, compiler: {name: applellvm, type: llvm}}
@@ -109,7 +108,7 @@ jobs:
             arch: {name: x64, type: x64}
             vcpkg: true
             export_mode: ON
-          - presets: {os: {name: ubuntu-20.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
+          - presets: {os: {name: ubuntu-latest, type: linux}, compiler: {name: gcc-11, type: gcc}}
             arch: {name: x64, type: x64}
             vcpkg: false
             export_mode: OFF
@@ -173,9 +172,10 @@ jobs:
           timeout 10s bash -c "while [ ! -f ~/.wine/system.reg ] ; do echo 'waiting for wine registry to be created' ; sleep 1 ; done" && echo "wine registry created"
           sed -i '/"PATH"/ s|"$|;Z:/usr/lib/gcc/x86_64-w64-mingw32/10-posix;Z:/usr/x86_64-w64-mingw32/lib"|g' ~/.wine/system.reg && echo "wine registry updated"
 
+      # skip asan on ubuntu-latest, see https://github.com/google/googletest/issues/4491
       - name: Configure CMake
         run: |
-          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
+          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.presets.os.type == 'linux' && '-DUSE_SANITIZER=OFF' || '' }} ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
 
       - name: Build
         run: |


### PR DESCRIPTION
Coverage test require gcov and lcov installed compatibly. Skip asan for now.

Related #89. Coverage on linux has downgraded to 22% because of the compatible issue between gcov and lcov.