### PR TITLE
style: fix typo and improve readablity

### DIFF
--- a/cmake/vcpkg/bootstrap/vcpkg_skip_install_on_reconfigure.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_skip_install_on_reconfigure.cmake
@@ -34,8 +34,8 @@ function(_vcpkg_skip_install_on_reconfigure)
         CACHE INTERNAL "")
   endif()
 
-  # I was not able to propgate vcpkg_manifest_hash via defer call, so workaround
-  # it with another cache variable.
+  # I was not able to propagate vcpkg_manifest_hash via defer call, so
+  # workaround it with another cache variable.
   set(__VCPKG_MANIFEST_HASH
       "${vcpkg_manifest_hash}"
       CACHE INTERNAL "")

--- a/docs/tutorials/commit_convention.md
+++ b/docs/tutorials/commit_convention.md
@@ -1,6 +1,6 @@
 # Commit Convention
 
-This guides the contributors to follow a consistent commit message format. And it helpes maintain a clean and readable git history and streamline the release process for release automation tools like semantic-release we use in this project.
+This guides the contributors to follow a consistent commit message format. And it helps maintain a clean and readable git history and streamline the release process for release automation tools like semantic-release we use in this project.
 
 ## For Release Automation
 
@@ -28,19 +28,19 @@ Commit Message Footer
 
 ### Commit Message Types
 
-| Type      | Description                                            |
-|-----------|--------------------------------------------------------|
-| `build`   | Changes that affect the build system or dependencies.  |
-| `chore`   | Routine tasks or changes outside the src/runtime code. |
-| `ci`      | Changes related to continuous integration.             |
-| `doc`     | Documentation changes.                                 |
-| `feat`    | New features.                                          |
-| `fix`     | Bug fixes.                                             |
-| `perf`    | Performance improvements.                              |
-| `refactor`| Code restructuring without changing behavior.          |
-| `revert`  | Revert a previous commit.                              |
-| `style`   | Code formatting changes.                               |
-| `test`    | Add or update tests.                                   |
+| Type       | Description                                            |
+|------------|--------------------------------------------------------|
+| `build`    | Changes that affect the build system or dependencies.  |
+| `chore`    | Routine tasks or changes outside the src/runtime code. |
+| `ci`       | Changes related to continuous integration.             |
+| `docs`     | Documentation changes.                                 |
+| `feat`     | New features.                                          |
+| `fix`      | Bug fixes.                                             |
+| `perf`     | Performance improvements.                              |
+| `refactor` | Code restructuring without changing behavior.          |
+| `revert`   | Revert a previous commit.                              |
+| `style`    | Code formatting changes.                               |
+| `test`     | Add or update tests.                                   |
 
 See the [release workflow](../topics/release_workflow.md) for more details how the configuration can be used to automate the release.
 

--- a/template/[% if docs_type == 'sphinx' %]docs[% endif %]/tutorials/commit_convention.md
+++ b/template/[% if docs_type == 'sphinx' %]docs[% endif %]/tutorials/commit_convention.md
@@ -1,6 +1,6 @@
 # Commit Convention
 
-This guides the contributors to follow a consistent commit message format. And it helpes maintain a clean and readable git history and streamline the release process for release automation tools like semantic-release we use in this project.
+This guides the contributors to follow a consistent commit message format. And it helps maintain a clean and readable git history and streamline the release process for release automation tools like semantic-release we use in this project.
 
 ## For Release Automation
 
@@ -28,19 +28,19 @@ Commit Message Footer
 
 ### Commit Message Types
 
-| Type      | Description                                            |
-|-----------|--------------------------------------------------------|
-| `build`   | Changes that affect the build system or dependencies.  |
-| `chore`   | Routine tasks or changes outside the src/runtime code. |
-| `ci`      | Changes related to continuous integration.             |
-| `doc`     | Documentation changes.                                 |
-| `feat`    | New features.                                          |
-| `fix`     | Bug fixes.                                             |
-| `perf`    | Performance improvements.                              |
-| `refactor`| Code restructuring without changing behavior.          |
-| `revert`  | Revert a previous commit.                              |
-| `style`   | Code formatting changes.                               |
-| `test`    | Add or update tests.                                   |
+| Type       | Description                                            |
+|------------|--------------------------------------------------------|
+| `build`    | Changes that affect the build system or dependencies.  |
+| `chore`    | Routine tasks or changes outside the src/runtime code. |
+| `ci`       | Changes related to continuous integration.             |
+| `docs`     | Documentation changes.                                 |
+| `feat`     | New features.                                          |
+| `fix`      | Bug fixes.                                             |
+| `perf`     | Performance improvements.                              |
+| `refactor` | Code restructuring without changing behavior.          |
+| `revert`   | Revert a previous commit.                              |
+| `style`    | Code formatting changes.                               |
+| `test`     | Add or update tests.                                   |
 
 See the [release workflow](../topics/release_workflow.md) for more details how the configuration can be used to automate the release.
 

--- a/template/cmake/vcpkg/bootstrap/vcpkg_skip_install_on_reconfigure.cmake
+++ b/template/cmake/vcpkg/bootstrap/vcpkg_skip_install_on_reconfigure.cmake
@@ -34,8 +34,8 @@ function(_vcpkg_skip_install_on_reconfigure)
         CACHE INTERNAL "")
   endif()
 
-  # I was not able to propgate vcpkg_manifest_hash via defer call, so workaround
-  # it with another cache variable.
+  # I was not able to propagate vcpkg_manifest_hash via defer call, so
+  # workaround it with another cache variable.
   set(__VCPKG_MANIFEST_HASH
       "${vcpkg_manifest_hash}"
       CACHE INTERNAL "")


### PR DESCRIPTION
Fix typo in cmake module `cmake/vcpkg/bootstrap/vcpkg_skip_install_on_reconfigure.cmake` and format.
Fix typo in `docs/tutorials/commit_convention.md` and format