### PR TITLE
chore: remove prCreation rule for renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,7 +6,6 @@
     ":maintainLockFilesWeekly"
   ],
   "platformAutomerge": true,
-  "prCreation":"not-pending",
   "packageRules": [
     {
       "matchDepTypes": [

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -6,7 +6,6 @@
     ":maintainLockFilesWeekly"
   ],
   "platformAutomerge": true,
-  "prCreation":"not-pending",
   "packageRules": [
 [%- if repo_name == 'ss-cpp' %]
     {


### PR DESCRIPTION
Because we have no github actions to run on the non-master/no-release branch causing the no-passed status, the renovate will not create any prs.