### PR TITLE
build: default CMAKE_COMPILE_WARNING_AS_ERROR as false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
+          cmake -S . --preset=${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
 
       - name: Build
         run: |

--- a/cmake/presets/base.json
+++ b/cmake/presets/base.json
@@ -16,7 +16,7 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "CMAKE_COMPILE_WARNING_AS_ERROR": false,
         "CMAKE_VERBOSE_MAKEFILE": "FALSE"
       }
     }

--- a/docs/topics/warnings.md
+++ b/docs/topics/warnings.md
@@ -13,7 +13,7 @@ The warning flags can be customized to pass the CMake configurable options:
 - `COMPILER_FLAGS_WARNINGS_GNU`: Flags for gcc/clang compilers.
 - `COMPILER_FLAGS_WARNINGS_MSVC`: Flags for msvc compilers.
 - `COMPILER_FLAGS_WARNINGS_CUDA`: Flags for cuda compilers.
-- `COMPILER_FLAGS_WARNINGS_AS_ERRORS`: If treat warnings as errors. Default is OFF.
+- `CMAKE_COMPILE_WARNING_AS_ERROR`: If treat warnings as errors. Default is false.
 - `COMPILER_FLAGS_SKIP_TARGETS_REGEXES`: List of regexes to skip targets. Default is empty.
 
 ```{note}

--- a/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]topics[% endif %]/warnings.md
+++ b/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]topics[% endif %]/warnings.md
@@ -13,7 +13,7 @@ The warning flags can be customized to pass the CMake configurable options:
 - `COMPILER_FLAGS_WARNINGS_GNU`: Flags for gcc/clang compilers.
 - `COMPILER_FLAGS_WARNINGS_MSVC`: Flags for msvc compilers.
 - `COMPILER_FLAGS_WARNINGS_CUDA`: Flags for cuda compilers.
-- `COMPILER_FLAGS_WARNINGS_AS_ERRORS`: If treat warnings as errors. Default is OFF.
+- `CMAKE_COMPILE_WARNING_AS_ERROR`: If treat warnings as errors. Default is false.
 - `COMPILER_FLAGS_SKIP_TARGETS_REGEXES`: List of regexes to skip targets. Default is empty.
 
 ```{note}

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
@@ -203,7 +203,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset={{ '${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == \'ON\' && \'-DVCPKG_EXPORT_MODE=ON\' || \'\' }}' }}
+          cmake -S . --preset={{ '${{ matrix.arch.type }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == \'ON\' && \'-DVCPKG_EXPORT_MODE=ON\' || \'\' }}' }}
 
       - name: Build
         run: |

--- a/template/cmake/presets/base.json
+++ b/template/cmake/presets/base.json
@@ -16,7 +16,7 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "CMAKE_COMPILE_WARNING_AS_ERROR": false,
         "CMAKE_VERBOSE_MAKEFILE": "FALSE"
       }
     }

--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -39,7 +39,7 @@
 [%- endif %]
     {
       "name": "cmake-modules",
-      "version": "1.4.18"
+      "version": "1.4.20"
     },
     {
       "name": "robotology-cmake-ycm",
@@ -50,7 +50,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "82d795ceb66aead215b464dedc3ebe533c71dd1e",
+        "baseline": "179d7e990100f79f75d7bf1ff42f5e2fbe41eac2",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
 [%- if use_conan == true %]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "cmake-modules",
-      "version": "1.4.18"
+      "version": "1.4.20"
     },
     {
       "name": "robotology-cmake-ycm",
@@ -27,7 +27,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "82d795ceb66aead215b464dedc3ebe533c71dd1e",
+        "baseline": "179d7e990100f79f75d7bf1ff42f5e2fbe41eac2",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
           "cmake-modules",


### PR DESCRIPTION
Because it will add `-Werror` or `/WX` to compile flags, and it is not suitable for distribution build.

See <https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#tldr-what-compiler-options-should-i-use>