### PR TITLE
perf: add auto triplet detection and simplify build

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 8
+    after_n_builds: 1
 coverage:
   status:
     project:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -34,29 +35,42 @@ jobs:
       - name: Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
-          path: ~/.cache/vcpkg
-          key: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
-          restore-keys: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
+          path: |
+            ~/vcpkg
+            ~/.cache/pip
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: gcc
+          compiler: gcc-13
           cmake: true
           ninja: true
           ccache: true
           doxygen: true
-          graphviz: true
-          python: true
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
 
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
 
       - name: Configure
-        run: cmake -S . --preset=x64-linux-gcc -DUSE_SANITIZER=OFF -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DUSE_SANITIZER=OFF
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=OFF
 
       - name: Build Docs
-        run: cmake --build out/build/x64-linux-gcc --target ss-cpp-docs
+        run: cmake --build out/build/default --target ss-cpp-docs
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
@@ -32,6 +31,7 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
+
 
   consistency:
     if: ${{ !cancelled() && ! failure() }}
@@ -79,53 +79,246 @@ jobs:
             exit 1 \
           )
 
-  checks:
-    runs-on: ${{ matrix.presets.os.name }}
+
+  check-on-linux:
+    runs-on: ubuntu-22.04
     needs: [pre-commit, consistency]
     timeout-minutes: 15
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     strategy:
       fail-fast: false
       matrix:
-        presets:
-          - {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-          - {os: {name: ubuntu-22.04, type: linux}, compiler: {name: llvm, type: llvm}}
-          - {os: {name: ubuntu-22.04, type: mingw-dynamic-linux}, compiler: {name: mingw, type: mingw}}
-          - {os: {name: macos-13, type: osx}, compiler: {name: applellvm, type: llvm}}
-          - {os: {name: macos-13, type: osx}, compiler: {name: llvm, type: llvm}}
-          # setup-cpp doesn't support mingw on macOS yet
-          # - {os: {name: macos-13, type: mingw-dynamic-darwin}, compiler: {name: mingw, type: mingw}}
-          - {os: {name: windows-2022, type: windows}, compiler: {name: msvc, type: msvc}}
-          - {os: {name: windows-2022, type: windows}, compiler: {name: llvm, type: llvm}}
-          - {os: {name: windows-2022, type: mingw-dynamic-windows}, compiler: {name: mingw, type: mingw}}
-        arch: [x64]
-        vcpkg: [true, false]
-        export_mode: [ON, OFF]
-        cppcheck: [true, false]
+        triplet: [x64-linux]
+        compiler: [gcc-13, llvm-17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
 
-        include:
-          - presets: {os: {name: windows-2022, type: windows}, compiler: {name: msvc, type: msvc}}
-            arch: x64
-            vcpkg: true
-            export_mode: ON
-            cppcheck: false
-          - presets: {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-            arch: x64
-            vcpkg: false
-            export_mode: OFF
-            cppcheck: false
-          - presets: {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-            arch: x64
-            vcpkg: true
-            export_mode: OFF
-            cppcheck: true
-        exclude:
-          - export_mode: ON
-          - vcpkg: false
-          - cppcheck: true
+    name: check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Prepare for lcov
+        if: contains(matrix.compiler, 'gcc')
+        run: |
+          sudo apt-get update; sudo apt-get install lcov -y
+          gcc_compiler=${{ matrix.compiler }}
+          gcov_version=${gcc_compiler##*-}
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$gcov_version 100
+
+      - name: Prepare for llvm-cov
+        if: contains(matrix.compiler, 'llvm')
+        run: |
+          llvm_compiler=${{ matrix.compiler }}
+          llvm_cov_version=${llvm_compiler##*-}
+          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-$llvm_cov_version 100
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+          -DCMAKE_C_COMPILER=${{ contains(matrix.compiler, 'gcc') && 'gcc' || contains(matrix.compiler, 'llvm') && 'clang' }}
+          -DCMAKE_CXX_COMPILER=${{ contains(matrix.compiler, 'gcc') && 'g++' || contains(matrix.compiler, 'llvm') && 'clang++' }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-on-macos:
+    runs-on: macos-12
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-osx]
+        compiler: [gcc-13, llvm@17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ contains(matrix.compiler, 'gcc') && matrix.compiler || '' }}
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Install ${{ matrix.compiler }} through brew
+        if: contains(matrix.compiler, 'llvm')
+        run: |
+          brew install ${{ matrix.compiler }}
+          echo "CC=/usr/local/opt/${{ matrix.compiler }}/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/local/opt/${{ matrix.compiler }}/bin/clang++" >> $GITHUB_ENV
+          echo "PATH=/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Prepare for lcov
+        if: contains(matrix.compiler, 'gcc')
+        run: |
+          curl -o /tmp/lcov.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/e92d2ae54954ebf485b484d8522104700b144fee/Formula/lcov.rb
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula /tmp/lcov.rb
+          brew pin lcov
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+          -DCMAKE_C_COMPILER="${CC}"
+          -DCMAKE_CXX_COMPILER="${CXX}"
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+          ${{ contains(matrix.compiler, 'gcc') && '-DCODE_COVERAGE_GCOV=${GCOV}' }}
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-on-windows:
+    runs-on: windows-2022
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-windows]
+        compiler: [msvc-2022, llvm-17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+            ~/AppData/Local/vcpkg
+          key: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+          vcvarsall: true
+          cmake: true
+          ninja: true
+          ccache: true
+          opencppcoverage: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default ${{ contains(matrix.compiler, 'llvm') && '-DVCPKG_PLATFORM_TOOLSET=ClangCL' || '' }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+          -DCMAKE_C_COMPILER=${{ contains(matrix.compiler, 'msvc') && '"cl"' || contains(matrix.compiler, 'llvm') && '"clang-cl.exe"' }}
+          -DCMAKE_CXX_COMPILER=${{ contains(matrix.compiler, 'msvc') && '"cl"' || contains(matrix.compiler, 'llvm') && '"clang-cl.exe"' }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DUSE_SANITIZER=${{ contains(matrix.compiler, 'llvm') && 'OFF' || 'ON' }}
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-mingw:
+    runs-on: windows-2022
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-mingw-dynamic]
+        compiler: [mingw]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -140,80 +333,51 @@ jobs:
             ~/.cache/pip
             ~/.cache/vcpkg
             ~/AppData/Local/vcpkg
-          key: |
-            ${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}-${{ hashFiles('vcpkg.json') }}-${{ matrix.vcpkg }}
-          restore-keys: |
-            ${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}-${{ hashFiles('vcpkg.json') }}-
+          key: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles('vcpkg.json') }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: ${{ matrix.presets.compiler.name }}
-          vcvarsall: ${{ contains(matrix.presets.os.type, 'windows' )}}
+          compiler: ${{ matrix.compiler }}
           cmake: true
           ninja: true
-          vcpkg: ${{ matrix.vcpkg }}
           ccache: true
-          cppcheck: ${{ matrix.cppcheck == true }}
-          python: true
-          opencppcoverage: ${{ contains(matrix.presets.os.type, 'windows' )}}
 
-      - name: Disable pre-installedd vcpkg for testing automaical vcpkg installation
-        if: ${{ matrix.vcpkg == false }}
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
+
+      - name: Install docs dependencies
         run: |
-          echo "VCPKG_INSTALLATION_ROOT=" >> $GITHUB_ENV
-
-      - name: Lcov for coverage
-        if: contains(matrix.presets.compiler.type, 'gcc') && contains(matrix.presets.os.type, 'linux')
-        run: |
-          sudo apt-get update
-          sudo apt-get install lcov
-
-      - name: Gcovr for coverage
-        if: contains(matrix.presets.compiler.type, 'mingw') && contains(matrix.presets.os.type, 'mingw')
-        run: |
-          pip install gcovr
-
-      - name: Target Windows on Linux (Mingw-w64)
-        if: contains(matrix.presets.compiler.type, 'mingw') && contains(matrix.presets.os.type, 'linux')
-        run: |
-          sudo apt-get update && sudo apt-get install mingw-w64 wine wine64 powershell
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
-          sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
-          wine64 true || true
-          echo "timeout 10s to execute a loop to check wine registry to be created"
-          timeout 10s bash -c "while [ ! -f ~/.wine/system.reg ] ; do echo 'waiting for wine registry to be created' ; sleep 1 ; done" && echo "wine registry created"
-          sed -i '/"PATH"/ s|"$|;Z:/usr/lib/gcc/x86_64-w64-mingw32/10-posix;Z:/usr/x86_64-w64-mingw32/lib"|g' ~/.wine/system.reg && echo "wine registry updated"
-
-      # see https://github.com/actions/runner-images/issues/9524
-      - name: Fix kernel mmap rnd bits
-        # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
-        # high-entropy ASLR in much newer kernels that GitHub runners are
-        # using leading to random crashes: https://reviews.llvm.org/D148280
-        if: contains(matrix.presets.compiler.type, 'gcc') && contains(matrix.presets.os.type, 'linux')
-        run: sudo sysctl vm.mmap_rnd_bits=28
+          pip install gcovr==7.2
 
       - name: Configure CMake
-        run: |
-          cmake -S . --preset=${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == 'ON' && '-DVCPKG_EXPORT_MODE=ON' || '' }}
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DUSE_SANITIZER=OFF
+          -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
 
       - name: Build
-        run: |
-          cmake --build out/build/${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} --target all
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
 
       - name: Coverage
-        run: |
-          cmake --build out/build/${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} --target ccov-all
+        run: cmake --build out/build/default --target ccov-all
 
-      - name: Upload coverage report
-        uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: out/build/${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }}/code_coverage
-          files: ./coverage.xml, ./coverage.info
-          flags: ${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}${{ matrix.vcpkg == true && '-vcpkg' || '' }}${{ matrix.export_mode == 'ON' && '-export' || '' }}${{ matrix.cppcheck == true && '-cppcheck' || '' }}
-          name: ${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}${{ matrix.vcpkg == true && '-vcpkg' || '' }}${{ matrix.export_mode == 'ON' && '-export' || '' }}${{ matrix.cppcheck == true && '-cppcheck' || '' }}-coverage
-
-  docs:
+  check-docs:
     name: Docs build and checks
     runs-on: ubuntu-22.04
     needs: [pre-commit, consistency]
@@ -221,40 +385,266 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
 
       - name: Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
-          path: ~/.cache/vcpkg
-          key: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
-          restore-keys: x64-linux-gcc-${{ hashFiles('vcpkg.json') }}
+          path: |
+            ~/vcpkg
+            ~/.cache/pip
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: gcc
+          compiler: gcc-13
           cmake: true
           ninja: true
           ccache: true
           doxygen: true
           graphviz: true
-          python: true
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
 
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
 
-      - name: Configure
-        run: cmake -S . --preset=x64-linux-gcc -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DUSE_SANITIZER=OFF
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=OFF
 
       - name: Checks the docs with warnings as errors
-        run: cmake --build out/build/x64-linux-gcc --target ss-cpp-docs-check
+        run: cmake --build out/build/default --target ss-cpp-docs-check
 
       - name: Checks the docs for broken links
-        run: cmake --build out/build/x64-linux-gcc --target ss-cpp-docs-linkcheck
+        run: cmake --build out/build/default --target ss-cpp-docs-linkcheck
+
+  codecov:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Prepare for lcov
+        run: |
+          sudo apt-get update; sudo apt-get install lcov -y
+          gcc_compiler=gcc-13
+          gcov_version=${gcc_compiler##*-}
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$gcov_version 100
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: out/build/default/code_coverage
+          files: ./coverage.info
+
+
+  check-export-mode:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+          -DVCPKG_EXPORT_MODE=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+
+  check-auto-vcpkg-install:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Disable preinstalled vcpkg in the runner to test vcpkg automatic installation
+        run: echo "VCPKG_INSTALLATION_ROOT=" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+
+  check-auto-detect-triplet:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+          restore-keys: x64-linux-gcc-13-${{ hashFiles('vcpkg.json') }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
 
   pass:
     if: always()
-    needs: [checks, docs]
+    needs: [check-on-linux, check-on-macos, check-on-windows, check-mingw, check-docs, codecov, check-export-mode, check-auto-vcpkg-install, check-auto-detect-triplet]
     runs-on: ubuntu-22.04
     timeout-minutes: 2
     steps:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,6 +6,7 @@
     "patch": 0
   },
   "include": [
+    "cmake/presets/default.json",
     "cmake/presets/x64-linux-llvm.json",
     "cmake/presets/x64-linux-gcc.json",
     "cmake/presets/x64-mingw-dynamic-windows-mingw.json",

--- a/cmake/ConfigureCoverage.cmake
+++ b/cmake/ConfigureCoverage.cmake
@@ -12,9 +12,13 @@ It supports detecting and using the following coverage tools:
 include_guard(GLOBAL)
 
 # cmake-format: off
-set(CODE_COVERAGE_GCOVR_REPORT_FORMAT xml)
+set(CODE_COVERAGE_GCOVR_REPORT_FORMAT xml CACHE STRING "Sets the gcovr report format.")
+set(CODE_COVERAGE_LCOV_EXTRA_FLAGS "--ignore-errors=gcov" CACHE STRING "Extra flags to pass to lcov")
 include(cmake-modules/test/Coverage)
-list(APPEND _excludes "${CMAKE_BINARY_DIR}" "${VCPKG_INSTALLED_DIR}" "${CMAKE_SOURCE_DIR}/vcpkg")
+list(APPEND _excludes "${CMAKE_BINARY_DIR}")
+if(VCPKG_EXPORT_MODE)
+  list(APPEND _excludes "${CMAKE_SOURCE_DIR}/cmake/vcpkg/export")
+endif()
 
 # Exclude system directories from code coverage
 if(NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")

--- a/cmake/presets/default.json
+++ b/cmake/presets/default.json
@@ -1,0 +1,51 @@
+{
+  "version": 6,
+  "include": [
+    "base.json",
+    "arch/x64.json",
+    "generators/ninja.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "default",
+      "inherits": [
+        "base",
+        "x64",
+        "ninja"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "inherits": "base",
+      "configurePreset": "default"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "inherits": "base",
+      "configurePreset": "default"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "default",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "default"
+        },
+        {
+          "type": "build",
+          "name": "default"
+        },
+        {
+          "type": "test",
+          "name": "default"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
@@ -134,9 +134,8 @@ endfunction()
 
 # find root
 function(_vcpkg_find_root cache_dir_name out_vcpkg_root)
-  if(DEFINED ENV{VCPKG_INSTALLATION_ROOT}
-     AND NOT "$ENV{VCPKG_INSTALLATION_ROOT}" STREQUAL "")
-    set(root "$ENV{VCPKG_INSTALLATION_ROOT}")
+  if(DEFINED ENV{VCPKG_ROOT} AND NOT "$ENV{VCPKG_ROOT}" STREQUAL "")
+    set(root "$ENV{VCPKG_ROOT}")
   elseif("${__vcpkg_bootstrap_host}" STREQUAL "Windows")
     set(root "$ENV{LOCALAPPDATA}/vcpkg/projects/${cache_dir_name}/cache")
   else()

--- a/cmake/vcpkg/bootstrap/vcpkg_export_mode.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_export_mode.cmake
@@ -43,6 +43,11 @@ function(_vcpkg_setup_export export_export_dir export_vcpkg_root)
       list(APPEND vcpkg_additional_manifest_params "--x-no-default-features")
     endif()
 
+    if(DEFINED VCPKG_HOST_TRIPLET AND NOT VCPKG_HOST_TRIPLET STREQUAL "")
+      list(APPEND vcpkg_additional_manifest_params
+           "--host-triplet=${VCPKG_HOST_TRIPLET}")
+    endif()
+
     set(_additional_args
         --vcpkg-root
         ${_VCPKG_ROOT}
@@ -52,8 +57,6 @@ function(_vcpkg_setup_export export_export_dir export_vcpkg_root)
         "${VCPKG_OVERLAY_TRIPLETS}"
         --triplet
         ${VCPKG_TARGET_TRIPLET}
-        --host-triplet
-        ${VCPKG_HOST_TRIPLET}
         --x-install-root
         "${_export_install_dir}")
 

--- a/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
@@ -3,13 +3,201 @@ SPDX-License-Identifier: MIT
 SPDX-FileCopyrightText: Copyright 2024 msclock
 ]]
 
+# copied from vcpkg vcpkg.cmake
+function(_vcpkg_detect_host_triplet)
+  if(DEFINED VCPKG_TARGET_TRIPLET)
+    return()
+  endif()
+
+  if(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
+    set(_detect_target_triplet_arch x86)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$")
+    set(_detect_target_triplet_arch x64)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$")
+    set(_detect_target_triplet_arch arm)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
+    set(_detect_target_triplet_arch arm64)
+  else()
+    if(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015 Win64")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015 ARM")
+      set(_detect_target_triplet_arch arm)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015")
+      set(_detect_target_triplet_arch x86)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017 Win64")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017 ARM")
+      set(_detect_target_triplet_arch arm)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017")
+      set(_detect_target_triplet_arch x86)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 16 2019"
+           AND CMAKE_VS_PLATFORM_NAME_DEFAULT STREQUAL "ARM64")
+      set(_detect_target_triplet_arch arm64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 16 2019")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 17 2022"
+           AND CMAKE_VS_PLATFORM_NAME_DEFAULT STREQUAL "ARM64")
+      set(_detect_target_triplet_arch arm64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 17 2022")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED
+                                                        CMAKE_OSX_ARCHITECTURES)
+      list(LENGTH CMAKE_OSX_ARCHITECTURES _detect_osx_arch_count)
+      if(_detect_osx_arch_count EQUAL "0")
+        message(
+          WARNING
+            "Unable to determine target architecture. "
+            "Consider providing a value for the CMAKE_OSX_ARCHITECTURES cache variable. "
+            "Continuing without vcpkg.")
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+
+      if(_detect_osx_arch_count GREATER "1")
+        message(
+          WARNING
+            "Detected more than one target architecture. Using the first one.")
+      endif()
+      list(GET CMAKE_OSX_ARCHITECTURES "0" _detect_osx_target_arch)
+      if(_detect_osx_target_arch STREQUAL "arm64")
+        set(_detect_target_triplet_arch arm64)
+      elseif(_detect_osx_target_arch STREQUAL "arm64s")
+        set(_detect_target_triplet_arch arm64s)
+      elseif(_detect_osx_target_arch STREQUAL "armv7s")
+        set(_detect_target_triplet_arch armv7s)
+      elseif(_detect_osx_target_arch STREQUAL "armv7")
+        set(_detect_target_triplet_arch arm)
+      elseif(_detect_osx_target_arch STREQUAL "x86_64")
+        set(_detect_target_triplet_arch x64)
+      elseif(_detect_osx_target_arch STREQUAL "i386")
+        set(_detect_target_triplet_arch x86)
+      else()
+        message(
+          WARNING
+            "Unable to determine target architecture, continuing without vcpkg."
+        )
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+    else()
+      find_program(Z_VCPKG_CL cl)
+      if(Z_VCPKG_CL MATCHES "amd64/cl.exe$" OR Z_VCPKG_CL MATCHES "x64/cl.exe$")
+        set(_detect_target_triplet_arch x64)
+      elseif(Z_VCPKG_CL MATCHES "arm/cl.exe$")
+        set(_detect_target_triplet_arch arm)
+      elseif(Z_VCPKG_CL MATCHES "arm64/cl.exe$")
+        set(_detect_target_triplet_arch arm64)
+      elseif(Z_VCPKG_CL MATCHES "bin/cl.exe$" OR Z_VCPKG_CL MATCHES
+                                                 "x86/cl.exe$")
+        set(_detect_target_triplet_arch x86)
+      elseif(
+        CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"
+        OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64"
+        OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+        set(_detect_target_triplet_arch x64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "s390x")
+        set(_detect_target_triplet_arch s390x)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+        set(_detect_target_triplet_arch ppc64le)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+        set(_detect_target_triplet_arch arm)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+        set(_detect_target_triplet_arch arm64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "riscv32")
+        set(_detect_target_triplet_arch riscv32)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "riscv64")
+        set(_detect_target_triplet_arch riscv64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "loongarch32")
+        set(_detect_target_triplet_arch loongarch32)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "loongarch64")
+        set(_detect_target_triplet_arch loongarch64)
+      else()
+        if(Z_VCPKG_CMAKE_IN_TRY_COMPILE)
+          message(
+            STATUS
+              "Unable to determine target architecture, continuing without vcpkg."
+          )
+        else()
+          message(
+            WARNING
+              "Unable to determine target architecture, continuing without vcpkg."
+          )
+        endif()
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+    endif()
+  endif()
+
+  # detect the target platform
+  if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR CMAKE_SYSTEM_NAME STREQUAL
+                                                  "WindowsPhone")
+    set(_detect_target_triplet_plat uwp)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux"))
+    set(_detect_target_triplet_plat linux)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin"
+            ))
+    set(_detect_target_triplet_plat osx)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(_detect_target_triplet_plat ios)
+  elseif(MINGW)
+    set(_detect_target_triplet_plat mingw-dynamic)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows"
+            ))
+    if(XBOX_CONSOLE_TARGET STREQUAL "scarlett")
+      set(_detect_target_triplet_plat xbox-scarlett)
+    elseif(XBOX_CONSOLE_TARGET STREQUAL "xboxone")
+      set(_detect_target_triplet_plat xbox-xboxone)
+    else()
+      set(_detect_target_triplet_plat windows)
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD"
+            ))
+    set(_detect_target_triplet_plat freebsd)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Android"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Android"
+            ))
+    set(_detect_target_triplet_plat android)
+  endif()
+
+  if(EMSCRIPTEN)
+    set(_detect_target_triplet_arch wasm32)
+    set(_detect_target_triplet_plat emscripten)
+  endif()
+
+  if(NOT _detect_target_triplet_arch STREQUAL ""
+     AND NOT _detect_target_triplet_plat STREQUAL "")
+    set(VCPKG_HOST_TRIPLET
+        "${_detect_target_triplet_arch}-${_detect_target_triplet_plat}"
+        PARENT_SCOPE)
+  endif()
+endfunction()
+
 # load the triplet by VCPKG_TARGET_TRIPLET
 macro(_vcpkg_load_triplet)
   if(NOT DEFINED VCPKG_TARGET_TRIPLET)
     message(
-      FATAL_ERROR
-        "VCPKG_TARGET_TRIPLET is not defined, please set it to the desired triplet"
+      WARNING
+        "VCPKG_TARGET_TRIPLET is not defined, detecting triplet from the system"
     )
+
+    _vcpkg_detect_host_triplet()
+
+    if(DEFINED VCPKG_HOST_TRIPLET)
+      set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_TRIPLET}")
+      message(STATUS "Detected triplet: ${VCPKG_TARGET_TRIPLET}")
+    else()
+      message(
+        FATAL_ERROR
+          "Unable to determine target triplet, please set it manually.")
+    endif()
   endif()
 
   set(_triplet "triplets/${VCPKG_TARGET_TRIPLET}.cmake")

--- a/cmake/vcpkg/vcpkg.toolchain.cmake
+++ b/cmake/vcpkg/vcpkg.toolchain.cmake
@@ -20,10 +20,15 @@ unset(IN_TRY_COMPILE)
 file(READ ${CMAKE_SOURCE_DIR}/vcpkg.json _vcpkg_json)
 string(JSON _builtin_baseline GET ${_vcpkg_json} builtin-baseline)
 
-# Respect VCPKG_ROOT environment variable if set
-if(DEFINED ENV{VCPKG_ROOT})
+# Respect environment variable VCPKG_ROOT and VCPKG_INSTALLATION_ROOT if set
+if(DEFINED ENV{VCPKG_ROOT} AND NOT "$ENV{VCPKG_ROOT}" STREQUAL "")
   set(_VCPKG_ROOT
       "$ENV{VCPKG_ROOT}"
+      CACHE PATH "Vcpkg root directory" FORCE)
+elseif(DEFINED ENV{VCPKG_INSTALLATION_ROOT}
+       AND NOT "$ENV{VCPKG_INSTALLATION_ROOT}" STREQUAL "")
+  set(_VCPKG_ROOT
+      "$ENV{VCPKG_INSTALLATION_ROOT}"
       CACHE PATH "Vcpkg root directory" FORCE)
 else()
   unset(_VCPKG_ROOT CACHE)

--- a/copier.yml
+++ b/copier.yml
@@ -173,7 +173,7 @@ use_codecov:
   type: bool
 
 codecov_notify_builds:
-  default: 8
+  default: 1
   help: 'Specify the number of builds to notify status for codecov:'
   type: int
   when: '{{ use_codecov == true }}'

--- a/docs/topics/triplet_presets.md
+++ b/docs/topics/triplet_presets.md
@@ -8,14 +8,13 @@ A triplet preset is a JSON file following the syntax of CMake CMakePresets.json 
 
 - Architecture: x86, x64, arm, arm64, ppc64le, s390x, wasm32, etc.
 - Target Compiling OS/Toolchain: windows, linux, macos, freebsd, android, ios, mingw, etc.
-- Distribution: dynamic, static, release, etc.
-- Compiler: MSVC, GCC, Clang, MinGW.
+- Distribution(Optional): dynamic, static, release, etc.
+- Compiler(Optional): MSVC, GCC, Clang, MinGW, etc.
 
 
-## Triplet Preset Creation
+## Triplet Preset Customization
 
-To create a triplet preset, we can refer to the existing triplet preset files in the `cmake/presets` directory and extend or modify them as per our requirements.
-
+To customize a triplet preset, we can refer to the existing triplet preset files in the `cmake/presets` directory and extend or modify them as per our requirements.
 
 ### Preset Folder Structure
 
@@ -36,4 +35,4 @@ Here are some best practices to follow while creating a triplet preset:
 
 - The triplet preset file should be named as `<Architecture>-<Target Compiling OS/Toolchain>-<Distribution>-<Compiler>.json`.
 - Conform to the existing triplet presets' folder structure.
-- Use existing components where possible.
+- Use existing components if possible.

--- a/docs/tutorials/building.md
+++ b/docs/tutorials/building.md
@@ -1,6 +1,6 @@
 # Building
 
-A general guide on how to build the project is provided here. The project uses CMake as the build system and vcpkg as the package manager.
+A general guide on how to build the project is provided here. The project uses CMake as the build system and vcpkg as the package manager. Essentially, we follow the vcpkg triplet and toolchain configuration to build the project.
 
 ## Prerequisites
 
@@ -42,21 +42,25 @@ But it is documented here for reference to reveal the underlying mechanism which
 
 The Table below shows the necessary variables for different platforms and configurations:
 
-| Variable               | Requirement | Description                             | Value                                                    |
-|------------------------|-------------|-----------------------------------------|----------------------------------------------------------|
-| CMAKE_TOOLCHAIN_FILE   | Required    | Path to the project's toolchain file    | cmake/vcpkg/vcpkg.toolchain.cmake                        |
-| CMAKE_BUILD_TYPE       | Required    | Build configuration                     | Debug, Release, RelWithDebInfo, MinSizeRel               |
-| CMAKE_GENERATOR        | Required    | Generator for the build system          | Ninja, Unix Makefiles, Visual Studio 16 2019, etc.       |
-| VCPKG_ROOT             | Optional    | Path to a vcpkg installation directory. | vcpkg installation directory                             |
-| VCPKG_TARGET_TRIPLET   | Required    | Target triplet                          | x86-windows, x64-windows, x64-linux, arm64-windows, etc. |
-| VCPKG_HOST_TRIPLET     | Optional    | Host triplet                            | x86-windows, x64-windows, x64-linux, arm64-windows, etc. |
-| VCPKG_OVERLAY_TRIPLETS | Optional    | Path to the overlay triplets directory  | cmake/vcpkg/triplets                                     |
-| VCPKG_OVERLAY_PORTS    | Optional    | Path to the overlay ports directory     | cmake/vcpkg/ports                                        |
+| Variable                | Requirement | Description                            | Allowed Values                              |
+|-------------------------|-------------|----------------------------------------|---------------------------------------------|
+| CMAKE_TOOLCHAIN_FILE    | Required    | Path to the project's toolchain file   | cmake/vcpkg/vcpkg.toolchain.cmake           |
+| CMAKE_BUILD_TYPE        | Required    | Build configuration                    | Debug, Release, RelWithDebInfo, MinSizeRel  |
+| CMAKE_GENERATOR         | Required    | Generator for the build system         | Ninja, Unix Makefiles, etc.                 |
+| VCPKG_TARGET_TRIPLET    | Required    | Target triplet                         | x64-windows, x64-linux, arm64-windows, etc. |
+| VCPKG_HOST_TRIPLET      | Optional    | Host triplet                           | x64-windows, x64-linux, arm64-windows, etc. |
+| VCPKG_ROOT              | Optional    | Path to a vcpkg installation directory | vcpkg installation directory                |
+| VCPKG_INSTALLATION_ROOT | Optional    | Path to a vcpkg installation directory | vcpkg installation directory                |
+| VCPKG_OVERLAY_TRIPLETS  | Optional    | Path to the overlay triplets directory | cmake/vcpkg/triplets                        |
+| VCPKG_OVERLAY_PORTS     | Optional    | Path to the overlay ports directory    | cmake/vcpkg/ports                           |
+| VCPKG_EXPORT_MODE       | Optional    | Enable vcpkg manifest mode             | OFF, ON                                     |
+| VCPKG_MANIFEST_FEATURES | Optional    | Enable vcpkg manifest features         | test                                        |
 
 ```{note}
  - `cmake/vcpkg/vcpkg.toolchain.cmake` contains the triplet and vcpkg environment initialization steps which loads triplet variables and chainload toolchain according to VCPKG_TARGET_TRIPLET.
- - `VCPKG_ROOT` is optional and it's used to specify the path to a vcpkg installation directory. If not specified, cmake/vcpkg/vcpkg.toolchain.cmake will automatically create one for you.
+ - `VCPKG_ROOT` and `VCPKG_INSTALLATION_ROOT` are same and both are optional and it's used to specify the path to a vcpkg installation directory. If not specified, cmake/vcpkg/vcpkg.toolchain.cmake will automatically create one for you.
  - `CMAKE_GENERATOR` is recommended to use Ninja as it's faster than the default generator.
+ - `VCPKG_HOST_TRIPLET` is optional and it is automatically detected by cmake/vcpkg/vcpkg.toolchain.cmake if not specified.
 ```
 
 Here's an example of building the project with the specified variables:
@@ -68,9 +72,10 @@ cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=Debug \
     -G Ninja \
     -DVCPKG_TARGET_TRIPLET=x64-linux \
-    -DVCPKG_HOST_TRIPLET=x64-linux \
     -DVCPKG_OVERLAY_TRIPLETS=cmake/vcpkg/triplets \
-    -DVCPKG_OVERLAY_PORTS=cmake/vcpkg/ports
+    -DVCPKG_OVERLAY_PORTS=cmake/vcpkg/ports \
+    -DVCPKG_MANIFEST_FEATURES=test # Enable test feature
+
 # Build
 cmake --build build --config Debug
 # Testing
@@ -78,7 +83,9 @@ cd build && ctest -C Debug -T test --output-on-failure
 # Memcheck
 cd build && ctest -C Debug -T memcheck
 # Install
-cmake --build build --config Debug --target install
+cmake --build build --target install
+# Uninstall
+cmake --build build --target uninstall
 ```
 
 Most of the variables can refer to <https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/cmake-integration>.
@@ -104,7 +111,7 @@ Because the command `vcpkg install` supports with vcpkg manifest file `vcpkg.jso
 
 ### Usage
 
-To use the export mode, a configuration variable `VCPKG_EXPORT_MANIFET` needs to pass to cmake configure step.
+To use the export mode, a configuration variable `VCPKG_EXPORT_MODE` needs to pass to cmake configure step.
 
 ```bash
 [cmake configure command] -DVCPKG_EXPORT_MODE=ON

--- a/template/CMakePresets.json
+++ b/template/CMakePresets.json
@@ -6,6 +6,7 @@
     "patch": 0
   },
   "include": [
+    "cmake/presets/default.json",
     "cmake/presets/x64-linux-llvm.json",
     "cmake/presets/x64-linux-gcc.json",
     "cmake/presets/x64-mingw-dynamic-windows-mingw.json",

--- a/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]topics[% endif %]/triplet_presets.md
+++ b/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]topics[% endif %]/triplet_presets.md
@@ -8,14 +8,13 @@ A triplet preset is a JSON file following the syntax of CMake CMakePresets.json 
 
 - Architecture: x86, x64, arm, arm64, ppc64le, s390x, wasm32, etc.
 - Target Compiling OS/Toolchain: windows, linux, macos, freebsd, android, ios, mingw, etc.
-- Distribution: dynamic, static, release, etc.
-- Compiler: MSVC, GCC, Clang, MinGW.
+- Distribution(Optional): dynamic, static, release, etc.
+- Compiler(Optional): MSVC, GCC, Clang, MinGW, etc.
 
 
-## Triplet Preset Creation
+## Triplet Preset Customization
 
-To create a triplet preset, we can refer to the existing triplet preset files in the `cmake/presets` directory and extend or modify them as per our requirements.
-
+To customize a triplet preset, we can refer to the existing triplet preset files in the `cmake/presets` directory and extend or modify them as per our requirements.
 
 ### Preset Folder Structure
 
@@ -36,4 +35,4 @@ Here are some best practices to follow while creating a triplet preset:
 
 - The triplet preset file should be named as `<Architecture>-<Target Compiling OS/Toolchain>-<Distribution>-<Compiler>.json`.
 - Conform to the existing triplet presets' folder structure.
-- Use existing components where possible.
+- Use existing components if possible.

--- a/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]tutorials[% endif %]/building.md
+++ b/template/[% if docs_type == 'sphinx' %]docs[% endif %]/[% if repo_name == 'ss-cpp' %]tutorials[% endif %]/building.md
@@ -1,6 +1,6 @@
 # Building
 
-A general guide on how to build the project is provided here. The project uses CMake as the build system and vcpkg as the package manager.
+A general guide on how to build the project is provided here. The project uses CMake as the build system and vcpkg as the package manager. Essentially, we follow the vcpkg triplet and toolchain configuration to build the project.
 
 ## Prerequisites
 
@@ -42,21 +42,25 @@ But it is documented here for reference to reveal the underlying mechanism which
 
 The Table below shows the necessary variables for different platforms and configurations:
 
-| Variable               | Requirement | Description                             | Value                                                    |
-|------------------------|-------------|-----------------------------------------|----------------------------------------------------------|
-| CMAKE_TOOLCHAIN_FILE   | Required    | Path to the project's toolchain file    | cmake/vcpkg/vcpkg.toolchain.cmake                        |
-| CMAKE_BUILD_TYPE       | Required    | Build configuration                     | Debug, Release, RelWithDebInfo, MinSizeRel               |
-| CMAKE_GENERATOR        | Required    | Generator for the build system          | Ninja, Unix Makefiles, Visual Studio 16 2019, etc.       |
-| VCPKG_ROOT             | Optional    | Path to a vcpkg installation directory. | vcpkg installation directory                             |
-| VCPKG_TARGET_TRIPLET   | Required    | Target triplet                          | x86-windows, x64-windows, x64-linux, arm64-windows, etc. |
-| VCPKG_HOST_TRIPLET     | Optional    | Host triplet                            | x86-windows, x64-windows, x64-linux, arm64-windows, etc. |
-| VCPKG_OVERLAY_TRIPLETS | Optional    | Path to the overlay triplets directory  | cmake/vcpkg/triplets                                     |
-| VCPKG_OVERLAY_PORTS    | Optional    | Path to the overlay ports directory     | cmake/vcpkg/ports                                        |
+| Variable                | Requirement | Description                            | Allowed Values                              |
+|-------------------------|-------------|----------------------------------------|---------------------------------------------|
+| CMAKE_TOOLCHAIN_FILE    | Required    | Path to the project's toolchain file   | cmake/vcpkg/vcpkg.toolchain.cmake           |
+| CMAKE_BUILD_TYPE        | Required    | Build configuration                    | Debug, Release, RelWithDebInfo, MinSizeRel  |
+| CMAKE_GENERATOR         | Required    | Generator for the build system         | Ninja, Unix Makefiles, etc.                 |
+| VCPKG_TARGET_TRIPLET    | Required    | Target triplet                         | x64-windows, x64-linux, arm64-windows, etc. |
+| VCPKG_HOST_TRIPLET      | Optional    | Host triplet                           | x64-windows, x64-linux, arm64-windows, etc. |
+| VCPKG_ROOT              | Optional    | Path to a vcpkg installation directory | vcpkg installation directory                |
+| VCPKG_INSTALLATION_ROOT | Optional    | Path to a vcpkg installation directory | vcpkg installation directory                |
+| VCPKG_OVERLAY_TRIPLETS  | Optional    | Path to the overlay triplets directory | cmake/vcpkg/triplets                        |
+| VCPKG_OVERLAY_PORTS     | Optional    | Path to the overlay ports directory    | cmake/vcpkg/ports                           |
+| VCPKG_EXPORT_MODE       | Optional    | Enable vcpkg manifest mode             | OFF, ON                                     |
+| VCPKG_MANIFEST_FEATURES | Optional    | Enable vcpkg manifest features         | test                                        |
 
 ```{note}
  - `cmake/vcpkg/vcpkg.toolchain.cmake` contains the triplet and vcpkg environment initialization steps which loads triplet variables and chainload toolchain according to VCPKG_TARGET_TRIPLET.
- - `VCPKG_ROOT` is optional and it's used to specify the path to a vcpkg installation directory. If not specified, cmake/vcpkg/vcpkg.toolchain.cmake will automatically create one for you.
+ - `VCPKG_ROOT` and `VCPKG_INSTALLATION_ROOT` are same and both are optional and it's used to specify the path to a vcpkg installation directory. If not specified, cmake/vcpkg/vcpkg.toolchain.cmake will automatically create one for you.
  - `CMAKE_GENERATOR` is recommended to use Ninja as it's faster than the default generator.
+ - `VCPKG_HOST_TRIPLET` is optional and it is automatically detected by cmake/vcpkg/vcpkg.toolchain.cmake if not specified.
 ```
 
 Here's an example of building the project with the specified variables:
@@ -68,9 +72,10 @@ cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=Debug \
     -G Ninja \
     -DVCPKG_TARGET_TRIPLET=x64-linux \
-    -DVCPKG_HOST_TRIPLET=x64-linux \
     -DVCPKG_OVERLAY_TRIPLETS=cmake/vcpkg/triplets \
-    -DVCPKG_OVERLAY_PORTS=cmake/vcpkg/ports
+    -DVCPKG_OVERLAY_PORTS=cmake/vcpkg/ports \
+    -DVCPKG_MANIFEST_FEATURES=test # Enable test feature
+
 # Build
 cmake --build build --config Debug
 # Testing
@@ -78,7 +83,9 @@ cd build && ctest -C Debug -T test --output-on-failure
 # Memcheck
 cd build && ctest -C Debug -T memcheck
 # Install
-cmake --build build --config Debug --target install
+cmake --build build --target install
+# Uninstall
+cmake --build build --target uninstall
 ```
 
 Most of the variables can refer to <https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/cmake-integration>.
@@ -104,7 +111,7 @@ Because the command `vcpkg install` supports with vcpkg manifest file `vcpkg.jso
 
 ### Usage
 
-To use the export mode, a configuration variable `VCPKG_EXPORT_MANIFET` needs to pass to cmake configure step.
+To use the export mode, a configuration variable `VCPKG_EXPORT_MODE` needs to pass to cmake configure step.
 
 ```bash
 [cmake configure command] -DVCPKG_EXPORT_MODE=ON

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/cd.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/cd.yml.jinja
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -34,29 +35,42 @@ jobs:
       - name: Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
-          path: ~/.cache/vcpkg
-          key: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
-          restore-keys: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          path: |
+            ~/vcpkg
+            ~/.cache/pip
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: gcc
+          compiler: gcc-13
           cmake: true
           ninja: true
           ccache: true
           doxygen: true
-          graphviz: true
-          python: true
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
 
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
 
       - name: Configure
-        run: cmake -S . --preset=x64-linux-gcc -DUSE_SANITIZER=OFF -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DUSE_SANITIZER=OFF
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=OFF
 
       - name: Build Docs
-        run: cmake --build out/build/x64-linux-gcc --target {{ repo_name }}-docs
+        run: cmake --build out/build/default --target {{ repo_name }}-docs
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
@@ -32,6 +31,7 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
+
 [% if repo_name == 'ss-cpp' %]
   consistency:
     if: {{ '${{ !cancelled() && ! failure() }}' }}
@@ -79,57 +79,262 @@ jobs:
             exit 1 \
           )
 [% endif %]
-  checks:
-    runs-on: {{ '${{ matrix.presets.os.name }}' }}
+
+  check-on-linux:
+    runs-on: ubuntu-22.04
     needs: [pre-commit
 [%- if repo_name == 'ss-cpp' -%]
     , consistency
 [%- endif -%]
     ]
     timeout-minutes: 15
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     strategy:
       fail-fast: false
       matrix:
-        presets:
-          - {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-          - {os: {name: ubuntu-22.04, type: linux}, compiler: {name: llvm, type: llvm}}
-          - {os: {name: ubuntu-22.04, type: mingw-dynamic-linux}, compiler: {name: mingw, type: mingw}}
-          - {os: {name: macos-13, type: osx}, compiler: {name: applellvm, type: llvm}}
-          - {os: {name: macos-13, type: osx}, compiler: {name: llvm, type: llvm}}
-          # setup-cpp doesn't support mingw on macOS yet
-          # - {os: {name: macos-13, type: mingw-dynamic-darwin}, compiler: {name: mingw, type: mingw}}
-          - {os: {name: windows-2022, type: windows}, compiler: {name: msvc, type: msvc}}
-          - {os: {name: windows-2022, type: windows}, compiler: {name: llvm, type: llvm}}
-          - {os: {name: windows-2022, type: mingw-dynamic-windows}, compiler: {name: mingw, type: mingw}}
-        arch: [x64]
-        vcpkg: [true, false]
-        export_mode: [ON, OFF]
-        cppcheck: [true, false]
+        triplet: [x64-linux]
+        compiler: [gcc-13, llvm-17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
 
-        include:
-          - presets: {os: {name: windows-2022, type: windows}, compiler: {name: msvc, type: msvc}}
-            arch: x64
-            vcpkg: true
-            export_mode: ON
-            cppcheck: false
-          - presets: {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-            arch: x64
-            vcpkg: false
-            export_mode: OFF
-            cppcheck: false
-          - presets: {os: {name: ubuntu-22.04, type: linux}, compiler: {name: gcc-11, type: gcc}}
-            arch: x64
-            vcpkg: true
-            export_mode: OFF
-            cppcheck: true
-        exclude:
-          - export_mode: ON
-          - vcpkg: false
-          - cppcheck: true
+    name: {{ 'check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}' }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: {{ '${{ matrix.compiler }}' }}
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Prepare for lcov
+        if: contains(matrix.compiler, 'gcc')
+        run: |
+          sudo apt-get update; sudo apt-get install lcov -y
+          gcc_compiler={{ '${{ matrix.compiler }}' }}
+          gcov_version=${gcc_compiler##*-}
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$gcov_version 100
+
+      - name: Prepare for llvm-cov
+        if: contains(matrix.compiler, 'llvm')
+        run: |
+          llvm_compiler={{ '${{ matrix.compiler }}' }}
+          llvm_cov_version=${llvm_compiler##*-}
+          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-$llvm_cov_version 100
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE={{ '${{ matrix.build_type }}' }}
+          -DCMAKE_CXX_STANDARD={{ '${{ matrix.std }}' }}
+          -DCMAKE_C_COMPILER={{ '${{ contains(matrix.compiler, \'gcc\') && \'gcc\' || contains(matrix.compiler, \'llvm\') && \'clang\' }}' }}
+          -DCMAKE_CXX_COMPILER={{ '${{ contains(matrix.compiler, \'gcc\') && \'g++\' || contains(matrix.compiler, \'llvm\') && \'clang++\' }}' }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET={{ '${{ matrix.triplet }}' }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-on-macos:
+    runs-on: macos-12
+    needs: [pre-commit
+[%- if repo_name == 'ss-cpp' -%]
+    , consistency
+[%- endif -%]
+    ]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-osx]
+        compiler: [gcc-13, llvm@17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: {{ 'check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}' }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: {{ '${{ contains(matrix.compiler, \'gcc\') && matrix.compiler || \'\' }}' }}
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Install {{ '${{ matrix.compiler }}' }} through brew
+        if: contains(matrix.compiler, 'llvm')
+        run: |
+          brew install {{ '${{ matrix.compiler }}' }}
+          echo "CC=/usr/local/opt/{{ '${{ matrix.compiler }}' }}/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/local/opt/{{ '${{ matrix.compiler }}' }}/bin/clang++" >> $GITHUB_ENV
+          echo "PATH=/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Prepare for lcov
+        if: contains(matrix.compiler, 'gcc')
+        run: |
+          curl -o /tmp/lcov.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/e92d2ae54954ebf485b484d8522104700b144fee/Formula/lcov.rb
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula /tmp/lcov.rb
+          brew pin lcov
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE={{ '${{ matrix.build_type }}' }}
+          -DCMAKE_CXX_STANDARD={{ '${{ matrix.std }}' }}
+          -DCMAKE_C_COMPILER="${CC}"
+          -DCMAKE_CXX_COMPILER="${CXX}"
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET={{ '${{ matrix.triplet }}' }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+          {{ '${{ contains(matrix.compiler, \'gcc\') && \'-DCODE_COVERAGE_GCOV=${GCOV}\' }}' }}
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-on-windows:
+    runs-on: windows-2022
+    needs: [pre-commit
+[%- if repo_name == 'ss-cpp' -%]
+    , consistency
+[%- endif -%]
+    ]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-windows]
+        compiler: [msvc-2022, llvm-17]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: {{ 'check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}' }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+            ~/AppData/Local/vcpkg
+          key: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: {{ '${{ matrix.compiler }}' }}
+          vcvarsall: true
+          cmake: true
+          ninja: true
+          ccache: true
+          opencppcoverage: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default {{ '${{ contains(matrix.compiler, \'llvm\') && \'-DVCPKG_PLATFORM_TOOLSET=ClangCL\' || \'\' }}' }}
+          -DCMAKE_BUILD_TYPE={{ '${{ matrix.build_type }}' }}
+          -DCMAKE_CXX_STANDARD={{ '${{ matrix.std }}' }}
+          -DCMAKE_C_COMPILER={{ '${{ contains(matrix.compiler, \'msvc\') && \'"cl"\' || contains(matrix.compiler, \'llvm\') && \'"clang-cl.exe"\' }}' }}
+          -DCMAKE_CXX_COMPILER={{ '${{ contains(matrix.compiler, \'msvc\') && \'"cl"\' || contains(matrix.compiler, \'llvm\') && \'"clang-cl.exe"\' }}' }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DUSE_SANITIZER={{ '${{ contains(matrix.compiler, \'llvm\') && \'OFF\' || \'ON\' }}' }}
+          -DVCPKG_TARGET_TRIPLET={{ '${{ matrix.triplet }}' }}
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+
+  check-mingw:
+    runs-on: windows-2022
+    needs: [pre-commit
+[%- if repo_name == 'ss-cpp' -%]
+    , consistency
+[%- endif -%]
+    ]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triplet: [x64-mingw-dynamic]
+        compiler: [mingw]
+        std: [20]
+        build_type: [Debug, RelWithDebInfo]
+
+    name: {{ 'check • ${{ matrix.triplet }} • ${{ matrix.compiler }} • c++${{ matrix.std }} • ${{ matrix.build_type }}' }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -144,81 +349,51 @@ jobs:
             ~/.cache/pip
             ~/.cache/vcpkg
             ~/AppData/Local/vcpkg
-          key: |
-            {{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}-${{ hashFiles(\'vcpkg.json\') }}-${{ matrix.vcpkg }}' }}
-          restore-keys: |
-            {{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}-${{ hashFiles(\'vcpkg.json\') }}-' }}
+          key: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: {{ '${{ matrix.triplet }}-${{ matrix.compiler }}-${{ hashFiles(\'vcpkg.json\') }}' }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: {{ '${{ matrix.presets.compiler.name }}' }}
-          vcvarsall: {{ '${{ contains(matrix.presets.os.type, \'windows\' )}}' }}
+          compiler: {{ '${{ matrix.compiler }}' }}
           cmake: true
           ninja: true
-          vcpkg: {{ '${{ matrix.vcpkg }}' }}
           ccache: true
-          cppcheck: {{ '${{ matrix.cppcheck == true }}' }}
-          python: true
-          opencppcoverage: {{ '${{ contains(matrix.presets.os.type, \'windows\' )}}' }}
 
-      - name: Disable pre-installedd vcpkg for testing automaical vcpkg installation
-        if: {{ '${{ matrix.vcpkg == false }}' }}
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
+
+      - name: Install docs dependencies
         run: |
-          echo "VCPKG_INSTALLATION_ROOT=" >> $GITHUB_ENV
-
-      - name: Lcov for coverage
-        if: contains(matrix.presets.compiler.type, 'gcc') && contains(matrix.presets.os.type, 'linux')
-        run: |
-          sudo apt-get update
-          sudo apt-get install lcov
-
-      - name: Gcovr for coverage
-        if: contains(matrix.presets.compiler.type, 'mingw') && contains(matrix.presets.os.type, 'mingw')
-        run: |
-          pip install gcovr
-
-      - name: Target Windows on Linux (Mingw-w64)
-        if: contains(matrix.presets.compiler.type, 'mingw') && contains(matrix.presets.os.type, 'linux')
-        run: |
-          sudo apt-get update && sudo apt-get install mingw-w64 wine wine64 powershell
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
-          sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
-          wine64 true || true
-          echo "timeout 10s to execute a loop to check wine registry to be created"
-          timeout 10s bash -c "while [ ! -f ~/.wine/system.reg ] ; do echo 'waiting for wine registry to be created' ; sleep 1 ; done" && echo "wine registry created"
-          sed -i '/"PATH"/ s|"$|;Z:/usr/lib/gcc/x86_64-w64-mingw32/10-posix;Z:/usr/x86_64-w64-mingw32/lib"|g' ~/.wine/system.reg && echo "wine registry updated"
-
-      # see https://github.com/actions/runner-images/issues/9524
-      - name: Fix kernel mmap rnd bits
-        # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
-        # high-entropy ASLR in much newer kernels that GitHub runners are
-        # using leading to random crashes: https://reviews.llvm.org/D148280
-        if: contains(matrix.presets.compiler.type, 'gcc') && contains(matrix.presets.os.type, 'linux')
-        run: sudo sysctl vm.mmap_rnd_bits=28
+          pip install gcovr==7.2
 
       - name: Configure CMake
-        run: |
-          cmake -S . --preset={{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCODE_COVERAGE=ON -DBUILD_TESTING=ON ${{ matrix.export_mode == \'ON\' && \'-DVCPKG_EXPORT_MODE=ON\' || \'\' }}' }}
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE={{ '${{ matrix.build_type }}' }}
+          -DCMAKE_CXX_STANDARD={{ '${{ matrix.std }}' }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DUSE_SANITIZER=OFF
+          -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
 
       - name: Build
-        run: |
-          cmake --build out/build/{{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }}' }} --target all
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
 
       - name: Coverage
-        run: |
-          cmake --build out/build/{{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }}' }} --target ccov-all
-[% if use_codecov == true %]
-      - name: Upload coverage report
-        uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
-        with:
-          token: {{ '${{ secrets.CODECOV_TOKEN }}' }}
-          directory: out/build/{{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.type }}' }}/code_coverage
-          files: ./coverage.xml, ./coverage.info
-          flags: {{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}${{ matrix.vcpkg == true && \'-vcpkg\' || \'\' }}${{ matrix.export_mode == \'ON\' && \'-export\' || \'\' }}${{ matrix.cppcheck == true && \'-cppcheck\' || \'\' }}' }}
-          name: {{ '${{ matrix.arch }}-${{ matrix.presets.os.type }}-${{ matrix.presets.compiler.name }}${{ matrix.vcpkg == true && \'-vcpkg\' || \'\' }}${{ matrix.export_mode == \'ON\' && \'-export\' || \'\' }}${{ matrix.cppcheck == true && \'-cppcheck\' || \'\' }}' }}-coverage
-[%- endif %]
+        run: cmake --build out/build/default --target ccov-all
 
-  docs:
+  check-docs:
     name: Docs build and checks
     runs-on: ubuntu-22.04
     needs: [pre-commit
@@ -230,40 +405,277 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
 
       - name: Cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
-          path: ~/.cache/vcpkg
-          key: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
-          restore-keys: x64-linux-gcc-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          path: |
+            ~/vcpkg
+            ~/.cache/pip
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
 
       - uses: aminya/setup-cpp@v1
         with:
-          compiler: gcc
+          compiler: gcc-13
           cmake: true
           ninja: true
           ccache: true
           doxygen: true
           graphviz: true
-          python: true
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: 3.x
 
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
 
-      - name: Configure
-        run: cmake -S . --preset=x64-linux-gcc -DBUILD_TESTING=OFF -DCODE_COVERAGE=OFF
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DUSE_SANITIZER=OFF
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=OFF
 
       - name: Checks the docs with warnings as errors
-        run: cmake --build out/build/x64-linux-gcc --target {{ repo_name }}-docs-check
+        run: cmake --build out/build/default --target {{ repo_name }}-docs-check
 
       - name: Checks the docs for broken links
-        run: cmake --build out/build/x64-linux-gcc --target {{ repo_name }}-docs-linkcheck
+        run: cmake --build out/build/default --target {{ repo_name }}-docs-linkcheck
+[% if use_codecov == true %]
+  codecov:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit
+[%- if repo_name == 'ss-cpp' -%]
+    , consistency
+[%- endif -%]
+    ]
+    timeout-minutes: 15
 
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Prepare for lcov
+        run: |
+          sudo apt-get update; sudo apt-get install lcov -y
+          gcc_compiler=gcc-13
+          gcov_version=${gcc_compiler##*-}
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$gcov_version 100
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=ON
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Coverage
+        run: cmake --build out/build/default --target ccov-all
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # v4.1.1
+        with:
+          token: {{ '${{ secrets.CODECOV_TOKEN }}' }}
+          directory: out/build/default/code_coverage
+          files: ./coverage.info
+[% endif %]
+[% if repo_name == 'ss-cpp' %]
+  check-export-mode:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+          -DVCPKG_EXPORT_MODE=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+[% endif %]
+[% if repo_name == 'ss-cpp' %]
+  check-auto-vcpkg-install:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Disable preinstalled vcpkg in the runner to test vcpkg automatic installation
+        run: echo "VCPKG_INSTALLATION_ROOT=" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+[% endif %]
+[% if repo_name == 'ss-cpp' %]
+  check-auto-detect-triplet:
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, consistency]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/vcpkg
+            ~/.cache/vcpkg
+          key: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+          restore-keys: x64-linux-gcc-13-{{ '${{ hashFiles(\'vcpkg.json\') }}' }}
+
+      - uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-13
+          cmake: true
+          ninja: true
+          ccache: true
+          cppcheck: true
+
+      - name: Configure CMake
+        run: >
+          cmake -S . --preset=default
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DCODE_COVERAGE=OFF
+          -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build out/build/default --target all
+
+      - name: Test
+        run: cmake --build out/build/default --target test
+
+      - name: Install
+        run: cmake --build out/build/default --target install
+
+      - name: Uninstall
+        run: cmake --build out/build/default --target uninstall
+[% endif %]
   pass:
     if: always()
-    needs: [checks, docs]
+    needs: [check-on-linux, check-on-macos, check-on-windows, check-mingw, check-docs
+[%- if use_codecov == true -%]
+    , codecov
+[%- endif -%]
+[%- if repo_name == 'ss-cpp' -%]
+    , check-export-mode, check-auto-vcpkg-install, check-auto-detect-triplet
+[%- endif -%]
+    ]
     runs-on: ubuntu-22.04
     timeout-minutes: 2
     steps:

--- a/template/cmake/ConfigureCoverage.cmake
+++ b/template/cmake/ConfigureCoverage.cmake
@@ -12,9 +12,13 @@ It supports detecting and using the following coverage tools:
 include_guard(GLOBAL)
 
 # cmake-format: off
-set(CODE_COVERAGE_GCOVR_REPORT_FORMAT xml)
+set(CODE_COVERAGE_GCOVR_REPORT_FORMAT xml CACHE STRING "Sets the gcovr report format.")
+set(CODE_COVERAGE_LCOV_EXTRA_FLAGS "--ignore-errors=gcov" CACHE STRING "Extra flags to pass to lcov")
 include(cmake-modules/test/Coverage)
-list(APPEND _excludes "${CMAKE_BINARY_DIR}" "${VCPKG_INSTALLED_DIR}" "${CMAKE_SOURCE_DIR}/vcpkg")
+list(APPEND _excludes "${CMAKE_BINARY_DIR}")
+if(VCPKG_EXPORT_MODE)
+  list(APPEND _excludes "${CMAKE_SOURCE_DIR}/cmake/vcpkg/export")
+endif()
 
 # Exclude system directories from code coverage
 if(NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")

--- a/template/cmake/presets/default.json
+++ b/template/cmake/presets/default.json
@@ -1,0 +1,51 @@
+{
+  "version": 6,
+  "include": [
+    "base.json",
+    "arch/x64.json",
+    "generators/ninja.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "default",
+      "inherits": [
+        "base",
+        "x64",
+        "ninja"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "inherits": "base",
+      "configurePreset": "default"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "inherits": "base",
+      "configurePreset": "default"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "default",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "default"
+        },
+        {
+          "type": "build",
+          "name": "default"
+        },
+        {
+          "type": "test",
+          "name": "default"
+        }
+      ]
+    }
+  ]
+}

--- a/template/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
+++ b/template/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
@@ -134,9 +134,8 @@ endfunction()
 
 # find root
 function(_vcpkg_find_root cache_dir_name out_vcpkg_root)
-  if(DEFINED ENV{VCPKG_INSTALLATION_ROOT}
-     AND NOT "$ENV{VCPKG_INSTALLATION_ROOT}" STREQUAL "")
-    set(root "$ENV{VCPKG_INSTALLATION_ROOT}")
+  if(DEFINED ENV{VCPKG_ROOT} AND NOT "$ENV{VCPKG_ROOT}" STREQUAL "")
+    set(root "$ENV{VCPKG_ROOT}")
   elseif("${__vcpkg_bootstrap_host}" STREQUAL "Windows")
     set(root "$ENV{LOCALAPPDATA}/vcpkg/projects/${cache_dir_name}/cache")
   else()

--- a/template/cmake/vcpkg/bootstrap/vcpkg_export_mode.cmake
+++ b/template/cmake/vcpkg/bootstrap/vcpkg_export_mode.cmake
@@ -43,6 +43,11 @@ function(_vcpkg_setup_export export_export_dir export_vcpkg_root)
       list(APPEND vcpkg_additional_manifest_params "--x-no-default-features")
     endif()
 
+    if(DEFINED VCPKG_HOST_TRIPLET AND NOT VCPKG_HOST_TRIPLET STREQUAL "")
+      list(APPEND vcpkg_additional_manifest_params
+           "--host-triplet=${VCPKG_HOST_TRIPLET}")
+    endif()
+
     set(_additional_args
         --vcpkg-root
         ${_VCPKG_ROOT}
@@ -52,8 +57,6 @@ function(_vcpkg_setup_export export_export_dir export_vcpkg_root)
         "${VCPKG_OVERLAY_TRIPLETS}"
         --triplet
         ${VCPKG_TARGET_TRIPLET}
-        --host-triplet
-        ${VCPKG_HOST_TRIPLET}
         --x-install-root
         "${_export_install_dir}")
 

--- a/template/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
+++ b/template/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
@@ -3,13 +3,201 @@ SPDX-License-Identifier: MIT
 SPDX-FileCopyrightText: Copyright 2024 msclock
 ]]
 
+# copied from vcpkg vcpkg.cmake
+function(_vcpkg_detect_host_triplet)
+  if(DEFINED VCPKG_TARGET_TRIPLET)
+    return()
+  endif()
+
+  if(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
+    set(_detect_target_triplet_arch x86)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$")
+    set(_detect_target_triplet_arch x64)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$")
+    set(_detect_target_triplet_arch arm)
+  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
+    set(_detect_target_triplet_arch arm64)
+  else()
+    if(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015 Win64")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015 ARM")
+      set(_detect_target_triplet_arch arm)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 14 2015")
+      set(_detect_target_triplet_arch x86)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017 Win64")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017 ARM")
+      set(_detect_target_triplet_arch arm)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 15 2017")
+      set(_detect_target_triplet_arch x86)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 16 2019"
+           AND CMAKE_VS_PLATFORM_NAME_DEFAULT STREQUAL "ARM64")
+      set(_detect_target_triplet_arch arm64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 16 2019")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 17 2022"
+           AND CMAKE_VS_PLATFORM_NAME_DEFAULT STREQUAL "ARM64")
+      set(_detect_target_triplet_arch arm64)
+    elseif(CMAKE_GENERATOR STREQUAL "Visual Studio 17 2022")
+      set(_detect_target_triplet_arch x64)
+    elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED
+                                                        CMAKE_OSX_ARCHITECTURES)
+      list(LENGTH CMAKE_OSX_ARCHITECTURES _detect_osx_arch_count)
+      if(_detect_osx_arch_count EQUAL "0")
+        message(
+          WARNING
+            "Unable to determine target architecture. "
+            "Consider providing a value for the CMAKE_OSX_ARCHITECTURES cache variable. "
+            "Continuing without vcpkg.")
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+
+      if(_detect_osx_arch_count GREATER "1")
+        message(
+          WARNING
+            "Detected more than one target architecture. Using the first one.")
+      endif()
+      list(GET CMAKE_OSX_ARCHITECTURES "0" _detect_osx_target_arch)
+      if(_detect_osx_target_arch STREQUAL "arm64")
+        set(_detect_target_triplet_arch arm64)
+      elseif(_detect_osx_target_arch STREQUAL "arm64s")
+        set(_detect_target_triplet_arch arm64s)
+      elseif(_detect_osx_target_arch STREQUAL "armv7s")
+        set(_detect_target_triplet_arch armv7s)
+      elseif(_detect_osx_target_arch STREQUAL "armv7")
+        set(_detect_target_triplet_arch arm)
+      elseif(_detect_osx_target_arch STREQUAL "x86_64")
+        set(_detect_target_triplet_arch x64)
+      elseif(_detect_osx_target_arch STREQUAL "i386")
+        set(_detect_target_triplet_arch x86)
+      else()
+        message(
+          WARNING
+            "Unable to determine target architecture, continuing without vcpkg."
+        )
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+    else()
+      find_program(Z_VCPKG_CL cl)
+      if(Z_VCPKG_CL MATCHES "amd64/cl.exe$" OR Z_VCPKG_CL MATCHES "x64/cl.exe$")
+        set(_detect_target_triplet_arch x64)
+      elseif(Z_VCPKG_CL MATCHES "arm/cl.exe$")
+        set(_detect_target_triplet_arch arm)
+      elseif(Z_VCPKG_CL MATCHES "arm64/cl.exe$")
+        set(_detect_target_triplet_arch arm64)
+      elseif(Z_VCPKG_CL MATCHES "bin/cl.exe$" OR Z_VCPKG_CL MATCHES
+                                                 "x86/cl.exe$")
+        set(_detect_target_triplet_arch x86)
+      elseif(
+        CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"
+        OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64"
+        OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+        set(_detect_target_triplet_arch x64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "s390x")
+        set(_detect_target_triplet_arch s390x)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+        set(_detect_target_triplet_arch ppc64le)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+        set(_detect_target_triplet_arch arm)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+        set(_detect_target_triplet_arch arm64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "riscv32")
+        set(_detect_target_triplet_arch riscv32)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "riscv64")
+        set(_detect_target_triplet_arch riscv64)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "loongarch32")
+        set(_detect_target_triplet_arch loongarch32)
+      elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "loongarch64")
+        set(_detect_target_triplet_arch loongarch64)
+      else()
+        if(Z_VCPKG_CMAKE_IN_TRY_COMPILE)
+          message(
+            STATUS
+              "Unable to determine target architecture, continuing without vcpkg."
+          )
+        else()
+          message(
+            WARNING
+              "Unable to determine target architecture, continuing without vcpkg."
+          )
+        endif()
+        set(VCPKG_TOOLCHAIN ON)
+        cmake_policy(POP)
+        return()
+      endif()
+    endif()
+  endif()
+
+  # detect the target platform
+  if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR CMAKE_SYSTEM_NAME STREQUAL
+                                                  "WindowsPhone")
+    set(_detect_target_triplet_plat uwp)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux"))
+    set(_detect_target_triplet_plat linux)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin"
+            ))
+    set(_detect_target_triplet_plat osx)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(_detect_target_triplet_plat ios)
+  elseif(MINGW)
+    set(_detect_target_triplet_plat mingw-dynamic)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows"
+            ))
+    if(XBOX_CONSOLE_TARGET STREQUAL "scarlett")
+      set(_detect_target_triplet_plat xbox-scarlett)
+    elseif(XBOX_CONSOLE_TARGET STREQUAL "xboxone")
+      set(_detect_target_triplet_plat xbox-xboxone)
+    else()
+      set(_detect_target_triplet_plat windows)
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD"
+            ))
+    set(_detect_target_triplet_plat freebsd)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Android"
+         OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Android"
+            ))
+    set(_detect_target_triplet_plat android)
+  endif()
+
+  if(EMSCRIPTEN)
+    set(_detect_target_triplet_arch wasm32)
+    set(_detect_target_triplet_plat emscripten)
+  endif()
+
+  if(NOT _detect_target_triplet_arch STREQUAL ""
+     AND NOT _detect_target_triplet_plat STREQUAL "")
+    set(VCPKG_HOST_TRIPLET
+        "${_detect_target_triplet_arch}-${_detect_target_triplet_plat}"
+        PARENT_SCOPE)
+  endif()
+endfunction()
+
 # load the triplet by VCPKG_TARGET_TRIPLET
 macro(_vcpkg_load_triplet)
   if(NOT DEFINED VCPKG_TARGET_TRIPLET)
     message(
-      FATAL_ERROR
-        "VCPKG_TARGET_TRIPLET is not defined, please set it to the desired triplet"
+      WARNING
+        "VCPKG_TARGET_TRIPLET is not defined, detecting triplet from the system"
     )
+
+    _vcpkg_detect_host_triplet()
+
+    if(DEFINED VCPKG_HOST_TRIPLET)
+      set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_TRIPLET}")
+      message(STATUS "Detected triplet: ${VCPKG_TARGET_TRIPLET}")
+    else()
+      message(
+        FATAL_ERROR
+          "Unable to determine target triplet, please set it manually.")
+    endif()
   endif()
 
   set(_triplet "triplets/${VCPKG_TARGET_TRIPLET}.cmake")

--- a/template/cmake/vcpkg/vcpkg.toolchain.cmake.jinja
+++ b/template/cmake/vcpkg/vcpkg.toolchain.cmake.jinja
@@ -20,10 +20,15 @@ unset(IN_TRY_COMPILE)
 file(READ ${CMAKE_SOURCE_DIR}/vcpkg.json _vcpkg_json)
 string(JSON _builtin_baseline GET ${_vcpkg_json} builtin-baseline)
 
-# Respect VCPKG_ROOT environment variable if set
-if(DEFINED ENV{VCPKG_ROOT})
+# Respect environment variable VCPKG_ROOT and VCPKG_INSTALLATION_ROOT if set
+if(DEFINED ENV{VCPKG_ROOT} AND NOT "$ENV{VCPKG_ROOT}" STREQUAL "")
   set(_VCPKG_ROOT
       "$ENV{VCPKG_ROOT}"
+      CACHE PATH "Vcpkg root directory" FORCE)
+elseif(DEFINED ENV{VCPKG_INSTALLATION_ROOT}
+       AND NOT "$ENV{VCPKG_INSTALLATION_ROOT}" STREQUAL "")
+  set(_VCPKG_ROOT
+      "$ENV{VCPKG_INSTALLATION_ROOT}"
       CACHE PATH "Vcpkg root directory" FORCE)
 else()
   unset(_VCPKG_ROOT CACHE)

--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -39,11 +39,11 @@
 [%- endif %]
     {
       "name": "cmake-modules",
-      "version": "1.4.26"
+      "version": "1.4.30"
     },
     {
       "name": "robotology-cmake-ycm",
-      "version": "0.15.3"
+      "version": "0.16.2"
     }
   ],
   "features": {
@@ -61,7 +61,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "2ddedaff948ef9ee241cba25b1a24be95fc86efc",
+        "baseline": "09e3f68327edeca50acbc3ebfe6fc21a2e467d34",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
 [%- if use_conan == true %]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,11 +16,11 @@
     },
     {
       "name": "cmake-modules",
-      "version": "1.4.26"
+      "version": "1.4.30"
     },
     {
       "name": "robotology-cmake-ycm",
-      "version": "0.15.3"
+      "version": "0.16.2"
     }
   ],
   "features": {
@@ -38,7 +38,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "2ddedaff948ef9ee241cba25b1a24be95fc86efc",
+        "baseline": "09e3f68327edeca50acbc3ebfe6fc21a2e467d34",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
           "cmake-modules",


### PR DESCRIPTION
Changes:
- simplifies all build chores, including cmake toolchain loading and CI/CD.
- adds the capability of the host triplet auto-detection.
- refine the documentation of relevant changes.

Close #160 