### PR TITLE
fix: git version header dirty detection

### DIFF
--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -39,7 +39,7 @@
 [%- endif %]
     {
       "name": "cmake-modules",
-      "version": "1.5.7"
+      "version": "1.5.9"
     },
     {
       "name": "robotology-cmake-ycm",
@@ -61,7 +61,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "8ccf9142cf83148839f244dc446aba608a387073",
+        "baseline": "ce7aea6deec0f4b78ad33f89b7bb4620f1215215",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
 [%- if use_conan == true %]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "cmake-modules",
-      "version": "1.5.7"
+      "version": "1.5.9"
     },
     {
       "name": "robotology-cmake-ycm",
@@ -38,7 +38,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "8ccf9142cf83148839f244dc446aba608a387073",
+        "baseline": "ce7aea6deec0f4b78ad33f89b7bb4620f1215215",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
           "cmake-modules",


### PR DESCRIPTION
Update cmake-modules v1.5.9 to fix version header
dirty detection. When not a init repo that causes
CMAKE_PROJECT_GIT_COMMIT_DIRTY to be undefined,
set CMAKE_PROJECT_GIT_COMMIT_DIRTY to 0 like nothing changed.

Related #319
Close #337 