### PR TITLE
fix: perfer ninja instead of ninja-multi-config

### DIFF
--- a/cmake/presets/base.json
+++ b/cmake/presets/base.json
@@ -9,7 +9,7 @@
       "name": "base",
       "hidden": true,
       "inherits": [
-        "ninja-multi-config",
+        "ninja",
         "vcpkg"
       ],
       "binaryDir": "${sourceDir}/out/build/${presetName}",
@@ -25,7 +25,7 @@
     {
       "name": "base",
       "hidden": true,
-      "inherits": "ninja-multi-config",
+      "inherits": "ninja",
       "configurePreset": "base"
     }
   ],
@@ -33,7 +33,7 @@
     {
       "name": "base",
       "hidden": true,
-      "inherits": "ninja-multi-config",
+      "inherits": "ninja",
       "configurePreset": "base",
       "output": {
         "outputOnFailure": true

--- a/cmake/presets/default.json
+++ b/cmake/presets/default.json
@@ -1,15 +1,13 @@
 {
   "version": 6,
   "include": [
-    "base.json",
-    "generators/ninja.json"
+    "base.json"
   ],
   "configurePresets": [
     {
       "name": "default",
       "inherits": [
-        "base",
-        "ninja"
+        "base"
       ]
     }
   ],

--- a/cmake/presets/generators/ninja.json
+++ b/cmake/presets/generators/ninja.json
@@ -21,7 +21,7 @@
       "name": "ninja-multi-config",
       "hidden": true,
       "configurePreset": "ninja-multi-config",
-      "configuration": "Debug"
+      "configuration": "RelWithDebInfo"
     }
   ],
   "testPresets": [
@@ -34,7 +34,7 @@
       "name": "ninja-multi-config",
       "hidden": true,
       "configurePreset": "ninja-multi-config",
-      "configuration": "Debug"
+      "configuration": "RelWithDebInfo"
     }
   ]
 }

--- a/template/cmake/presets/base.json
+++ b/template/cmake/presets/base.json
@@ -9,7 +9,7 @@
       "name": "base",
       "hidden": true,
       "inherits": [
-        "ninja-multi-config",
+        "ninja",
         "vcpkg"
       ],
       "binaryDir": "${sourceDir}/out/build/${presetName}",
@@ -25,7 +25,7 @@
     {
       "name": "base",
       "hidden": true,
-      "inherits": "ninja-multi-config",
+      "inherits": "ninja",
       "configurePreset": "base"
     }
   ],
@@ -33,7 +33,7 @@
     {
       "name": "base",
       "hidden": true,
-      "inherits": "ninja-multi-config",
+      "inherits": "ninja",
       "configurePreset": "base",
       "output": {
         "outputOnFailure": true

--- a/template/cmake/presets/default.json
+++ b/template/cmake/presets/default.json
@@ -1,15 +1,13 @@
 {
   "version": 6,
   "include": [
-    "base.json",
-    "generators/ninja.json"
+    "base.json"
   ],
   "configurePresets": [
     {
       "name": "default",
       "inherits": [
-        "base",
-        "ninja"
+        "base"
       ]
     }
   ],

--- a/template/cmake/presets/generators/ninja.json
+++ b/template/cmake/presets/generators/ninja.json
@@ -21,7 +21,7 @@
       "name": "ninja-multi-config",
       "hidden": true,
       "configurePreset": "ninja-multi-config",
-      "configuration": "Debug"
+      "configuration": "RelWithDebInfo"
     }
   ],
   "testPresets": [
@@ -34,7 +34,7 @@
       "name": "ninja-multi-config",
       "hidden": true,
       "configurePreset": "ninja-multi-config",
-      "configuration": "Debug"
+      "configuration": "RelWithDebInfo"
     }
   ]
 }


### PR DESCRIPTION
When use ninja-multi-config , all cmake build and
test commands without `--config` adopt Debug
configuration by default before. Switch to ninja
makes it run as expected.