### PR TITLE
build: pin fmt 10.2.1

### DIFF
--- a/src/compile/CMakeLists.txt
+++ b/src/compile/CMakeLists.txt
@@ -27,9 +27,6 @@ target_include_interface_directories(
   ${CMAKE_CURRENT_BINARY_DIR}/git_version # for git hash
 )
 
-target_compile_options(
-  ${target_name} PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>")
-
 target_link_libraries(${target_name} PRIVATE spdlog::spdlog)
 
 set_target_properties(

--- a/template/src/[% if compile_target != '' %]{{ compile_target }}[% endif %]/CMakeLists.txt.jinja
+++ b/template/src/[% if compile_target != '' %]{{ compile_target }}[% endif %]/CMakeLists.txt.jinja
@@ -27,9 +27,6 @@ target_include_interface_directories(
   ${CMAKE_CURRENT_BINARY_DIR}/git_version # for git hash
 )
 
-target_compile_options(
-  ${target_name} PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>")
-
 target_link_libraries(${target_name} PRIVATE spdlog::spdlog)
 
 set_target_properties(

--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -7,6 +7,7 @@
   "homepage": "https://{{ repo_url() }}",
   "dependencies": [
 [%- if compile_target != '' or exe_target != '' or header_target != '' %]
+    "fmt",
     "spdlog",
 [%- endif %]
 [%- if use_conan == true %]
@@ -20,6 +21,11 @@
   ],
   "overrides": [
 [%- if compile_target != '' or exe_target != '' or header_target != '' %]
+    {
+      "name": "fmt",
+      "version": "10.2.1",
+      "port-version": 2
+    },
     {
       "name": "spdlog",
       "version": "1.13.0"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,11 +5,17 @@
   "builtin-baseline": "cacf5994341f27e9a14a7b8724b0634b138ecb30",
   "homepage": "https://github.com/serious-scaffold/ss-cpp",
   "dependencies": [
+    "fmt",
     "spdlog",
     "cmake-modules",
     "robotology-cmake-ycm"
   ],
   "overrides": [
+    {
+      "name": "fmt",
+      "version": "10.2.1",
+      "port-version": 2
+    },
     {
       "name": "spdlog",
       "version": "1.13.0"


### PR DESCRIPTION
For incoming pr #340, this pr prepares for passing compilation when it uses fmt 11.0.2 implicitly from spdlog. So we pin it explicitly.