### PR TITLE
fix: correct cmake presets for vscode resolution

### DIFF
--- a/cmake/presets/base.json
+++ b/cmake/presets/base.json
@@ -17,6 +17,7 @@
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_COMPILE_WARNING_AS_ERROR": false,
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_VERBOSE_MAKEFILE": "FALSE"
       }
     }

--- a/cmake/presets/generators/ninja.json
+++ b/cmake/presets/generators/ninja.json
@@ -15,7 +15,9 @@
   "buildPresets": [
     {
       "name": "ninja",
-      "hidden": true
+      "hidden": true,
+      "configurePreset": "ninja",
+      "configuration":"RelWithDebInfo"
     },
     {
       "name": "ninja-multi-config",
@@ -28,7 +30,8 @@
     {
       "name": "ninja",
       "hidden": true,
-      "configurePreset": "ninja"
+      "configurePreset": "ninja",
+      "configuration": "RelWithDebInfo"
     },
     {
       "name": "ninja-multi-config",

--- a/template/cmake/presets/base.json
+++ b/template/cmake/presets/base.json
@@ -17,6 +17,7 @@
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_COMPILE_WARNING_AS_ERROR": false,
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_VERBOSE_MAKEFILE": "FALSE"
       }
     }

--- a/template/cmake/presets/generators/ninja.json
+++ b/template/cmake/presets/generators/ninja.json
@@ -15,7 +15,9 @@
   "buildPresets": [
     {
       "name": "ninja",
-      "hidden": true
+      "hidden": true,
+      "configurePreset": "ninja",
+      "configuration":"RelWithDebInfo"
     },
     {
       "name": "ninja-multi-config",
@@ -28,7 +30,8 @@
     {
       "name": "ninja",
       "hidden": true,
-      "configurePreset": "ninja"
+      "configurePreset": "ninja",
+      "configuration": "RelWithDebInfo"
     },
     {
       "name": "ninja-multi-config",


### PR DESCRIPTION
Refer https://github.com/microsoft/vscode-cmake-tools/discussions/3998. 

This is a workaround to support vscode cmake-tools plugin to launch a debugger for cmake targets.