### PR TITLE
build: refine vcpkg bootstrap

### DIFF
--- a/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
@@ -176,7 +176,7 @@ endfunction()
 macro(_vcpkg_load_triplet)
   if(NOT DEFINED VCPKG_TARGET_TRIPLET)
     message(
-      WARNING
+      STATUS
         "VCPKG_TARGET_TRIPLET is not defined, detecting triplet from the system"
     )
 

--- a/template/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
+++ b/template/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
@@ -176,7 +176,7 @@ endfunction()
 macro(_vcpkg_load_triplet)
   if(NOT DEFINED VCPKG_TARGET_TRIPLET)
     message(
-      WARNING
+      STATUS
         "VCPKG_TARGET_TRIPLET is not defined, detecting triplet from the system"
     )
 


### PR DESCRIPTION
- Fetch commit hash instead of unshallowing full repo of vcpkg.
- Suppress vcpkg triplet detection warning.
- Bootstrap vcpkg-tool with a retry.