### PR TITLE
perf: refine automerge strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -975,5 +975,5 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
       - name: Approve pr if all jobs succeeded
-        if: contains(github.event.pull_request.labels.*.name, 'auto-approval')
+        if: contains(github.event.pull_request.labels.*.name, 'auto-approval') && contains(github.actor, '[bot]')
         uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,8 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '*/15 0-3 * * 1'
+    # Match renovate schedule:earlyMondays and schedule:automergeMonthly
+    - cron: '*/15 0-3 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,14 +3,29 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    ":enablePreCommit",
-    ":maintainLockFilesWeekly"
+    ":enablePreCommit"
   ],
   "automergeType": "pr",
   "automergeStrategy": "merge-commit",
   "ignoreScripts": false,
   "platformAutomerge": true,
   "packageRules": [
+    {
+      "automerge": true,
+      "addLabels": [
+        "auto-approval"
+      ],
+      "extends": [
+        "schedule:earlyMondays",
+        "schedule:automergeMonthly"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
     {
       "matchDepTypes": [
         "action"
@@ -57,7 +72,6 @@
     {
       "description": "Group vcpkg.json baseline with auto-update",
       "groupName": "group vcpkg-baseline",
-      "extends": ["schedule:automergeMonthly"],
       "addLabels": [
         "auto-approval",
         "vcpkg-baseline"
@@ -69,7 +83,6 @@
       "matchFileNames": [
         "vcpkg.json"
       ],
-      "automerge": true,
       "postUpgradeTasks": {
         "commands": [
           "find template -type f -name 'vcpkg.json.jinja' -exec sed -i 's|{{{currentDigest}}}|{{{newDigest}}}|g' {} +"
@@ -79,16 +92,13 @@
     {
       "description": "Group renovate docker tag and pre-commit-hooks tag",
       "groupName": "renovate group",
-      "extends": ["schedule:automergeMonthly"],
       "addLabels": [
-        "auto-approval",
         "renovate"
       ],
       "matchDatasources": [
         "docker",
         "github-tags"
       ],
-      "automerge": true,
       "matchDepNames": [
         "ghcr.io/renovatebot/renovate",
         "renovate/renovate",

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -5,14 +5,29 @@
 [%- if repo_name == 'ss-cpp' or repo_platform == 'github' %]
     "helpers:pinGitHubActionDigests",
 [%- endif %]
-    ":enablePreCommit",
-    ":maintainLockFilesWeekly"
+    ":enablePreCommit"
   ],
   "automergeType": "pr",
   "automergeStrategy": "merge-commit",
   "ignoreScripts": false,
   "platformAutomerge": true,
   "packageRules": [
+    {
+      "automerge": true,
+      "addLabels": [
+        "auto-approval"
+      ],
+      "extends": [
+        "schedule:earlyMondays",
+        "schedule:automergeMonthly"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
 [%- if repo_name == 'ss-cpp' %]
     {
       "matchDepTypes": [
@@ -60,7 +75,6 @@
     {
       "description": "Group vcpkg.json baseline with auto-update",
       "groupName": "group vcpkg-baseline",
-      "extends": ["schedule:automergeMonthly"],
       "addLabels": [
 [%- if repo_platform == 'github' %]
         "auto-approval",
@@ -74,7 +88,6 @@
       "matchFileNames": [
         "vcpkg.json"
       ],
-      "automerge": true,
       "postUpgradeTasks": {
         "commands": [
           "find template -type f -name 'vcpkg.json.jinja' -exec sed -i {{ '\'s|{{{currentDigest}}}|{{{newDigest}}}|g\'' }} {} +"
@@ -85,18 +98,13 @@
     {
       "description": "Group renovate docker tag and pre-commit-hooks tag",
       "groupName": "renovate group",
-      "extends": ["schedule:automergeMonthly"],
       "addLabels": [
-[%- if repo_platform == 'github' %]
-        "auto-approval",
-[%- endif %]
         "renovate"
       ],
       "matchDatasources": [
         "docker",
         "github-tags"
       ],
-      "automerge": true,
       "matchDepNames": [
 [%- if repo_platform == 'github' %]
         "ghcr.io/renovatebot/renovate",

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/ci.yml.jinja
@@ -1023,5 +1023,5 @@ jobs:
           jobs: {{ '${{ toJSON(needs) }}' }}
 
       - name: Approve pr if all jobs succeeded
-        if: contains(github.event.pull_request.labels.*.name, 'auto-approval')
+        if: contains(github.event.pull_request.labels.*.name, 'auto-approval') && contains(github.actor, '[bot]')
         uses: hmarr/auto-approve-action@v4

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -2,7 +2,8 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '*/15 0-3 * * 1'
+    # Match renovate schedule:earlyMondays and schedule:automergeMonthly
+    - cron: '*/15 0-3 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Only do auto approval on `[bot]` accounts.
- Schedule weekly and automerge monthly for non-major dependency updates.
- Run renovate every 15 mins from 0 to 3 o'clock on monday.