### PR TITLE
fix: use renovate automerge schedule

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,7 +8,7 @@
   "automergeType": "pr",
   "automergeStrategy": "merge-commit",
   "ignoreScripts": false,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "packageRules": [
     {
       "automerge": true,

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -10,7 +10,7 @@
   "automergeType": "pr",
   "automergeStrategy": "merge-commit",
   "ignoreScripts": false,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "packageRules": [
     {
       "automerge": true,


### PR DESCRIPTION
Need to set platformAutomerge to false and instead rely on Renovate's automerge instead of the platform one.

See https://docs.renovatebot.com/configuration-options/#automergeschedule.