### PR TITLE
perf: update spdlog and fmt

### DIFF
--- a/cmake/vcpkg/ports/fmt/fix-write-batch.patch
+++ b/cmake/vcpkg/ports/fmt/fix-write-batch.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 88c12148..967b53dd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -260,7 +260,7 @@ if (FMT_MASTER_PROJECT AND CMAKE_GENERATOR MATCHES "Visual Studio")
+   join(netfxpath
+        "C:\\Program Files\\Reference Assemblies\\Microsoft\\Framework\\"
+        ".NETFramework\\v4.0")
+-  file(WRITE run-msbuild.bat "
++  file(WRITE "${CMAKE_BINARY_DIR}/run-msbuild.bat" "
+     ${MSBUILD_SETUP}
+     ${CMAKE_MAKE_PROGRAM} -p:FrameworkPathOverride=\"${netfxpath}\" %*")
+ endif ()

--- a/cmake/vcpkg/ports/fmt/portfile.cmake
+++ b/cmake/vcpkg/ports/fmt/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fmtlib/fmt
+    REF "${VERSION}"
+    SHA512 46974efd36e613477351aa357c451cee434da797c2a505f9f86d73e394dcb35dc2dc0cda66abb98c023e8f24deac9d8e3ee6f9f6c0971cc4c00e37c34aa7f15f
+    HEAD_REF master
+    PATCHES
+        fix-write-batch.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFMT_CMAKE_DIR=share/fmt
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fmt/base.h"
+        "defined(FMT_SHARED)"
+        "1"
+    )
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cmake/vcpkg/ports/fmt/usage
+++ b/cmake/vcpkg/ports/fmt/usage
@@ -1,0 +1,8 @@
+The package fmt provides CMake targets:
+
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt)
+
+    # Or use the header-only version
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt-header-only)

--- a/cmake/vcpkg/ports/fmt/vcpkg.json
+++ b/cmake/vcpkg/ports/fmt/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "fmt",
+  "version": "11.2.0",
+  "port-version": 1,
+  "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
+  "homepage": "https://github.com/fmtlib/fmt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/template/cmake/vcpkg/ports/fmt/fix-write-batch.patch
+++ b/template/cmake/vcpkg/ports/fmt/fix-write-batch.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 88c12148..967b53dd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -260,7 +260,7 @@ if (FMT_MASTER_PROJECT AND CMAKE_GENERATOR MATCHES "Visual Studio")
+   join(netfxpath
+        "C:\\Program Files\\Reference Assemblies\\Microsoft\\Framework\\"
+        ".NETFramework\\v4.0")
+-  file(WRITE run-msbuild.bat "
++  file(WRITE "${CMAKE_BINARY_DIR}/run-msbuild.bat" "
+     ${MSBUILD_SETUP}
+     ${CMAKE_MAKE_PROGRAM} -p:FrameworkPathOverride=\"${netfxpath}\" %*")
+ endif ()

--- a/template/cmake/vcpkg/ports/fmt/portfile.cmake
+++ b/template/cmake/vcpkg/ports/fmt/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fmtlib/fmt
+    REF "${VERSION}"
+    SHA512 46974efd36e613477351aa357c451cee434da797c2a505f9f86d73e394dcb35dc2dc0cda66abb98c023e8f24deac9d8e3ee6f9f6c0971cc4c00e37c34aa7f15f
+    HEAD_REF master
+    PATCHES
+        fix-write-batch.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFMT_CMAKE_DIR=share/fmt
+        -DFMT_TEST=OFF
+        -DFMT_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/fmt/base.h"
+        "defined(FMT_SHARED)"
+        "1"
+    )
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/template/cmake/vcpkg/ports/fmt/usage
+++ b/template/cmake/vcpkg/ports/fmt/usage
@@ -1,0 +1,8 @@
+The package fmt provides CMake targets:
+
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt)
+
+    # Or use the header-only version
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt-header-only)

--- a/template/cmake/vcpkg/ports/fmt/vcpkg.json
+++ b/template/cmake/vcpkg/ports/fmt/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "fmt",
+  "version": "11.2.0",
+  "port-version": 1,
+  "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
+  "homepage": "https://github.com/fmtlib/fmt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -22,12 +22,11 @@
 [%- if compile_target != '' or exe_target != '' or header_target != '' %]
     {
       "name": "fmt",
-      "version": "10.2.1",
-      "port-version": 2
+      "version": "11.2.0"
     },
     {
       "name": "spdlog",
-      "version": "1.13.0"
+      "version": "1.15.2"
     },
 [%- endif %]
 [%- if use_conan == true %]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,12 +13,11 @@
   "overrides": [
     {
       "name": "fmt",
-      "version": "10.2.1",
-      "port-version": 2
+      "version": "11.2.0"
     },
     {
       "name": "spdlog",
-      "version": "1.13.0"
+      "version": "1.15.2"
     },
     {
       "name": "cmake-modules",


### PR DESCRIPTION
Fix the build errors like `call to consteval function 'fmt::basic_format_string<char, const char *, const char *&, int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression`